### PR TITLE
Issue#19: context.Context を全レイヤーに伝播させる

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,12 +1,7 @@
-export NYAN_SERVER_PORT=8999
-export NYAN_MESSAGE_TOKEN=token
-
-export NYAN_CHANNEL_SECRET=line_channel_secret
-export NYAN_ACCESS_TOKEN=line_access_token
-export NYAN_DEFAULT_ROOM_ID=default_room_id
-
-export NYAN_SHEET_ID=sheet_id
-export NYAN_GOOGLE_CLIENT_EMAIL=service_account_email
-export NYAN_GOOGLE_PRIVATE_KEY=private_key
-export NYAN_GOOGLE_PRIVATE_KEY_ID=private_key_id
-export NYAN_GOOGLE_TOKEN_URL=https://oauth2.googleapis.com/token
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  key="${line%%=*}"
+  value="${line#*=}"
+  export "$key"="$value"
+done < envfile

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,6 +14,12 @@ tasks:
     cmds:
       - go test ./...
 
+  serve:
+    desc: ローカルでserverを起動 (envfileを読み込む)
+    dotenv: ['envfile']
+    cmds:
+      - go run cmd/nyan/nyan.go server
+
   release:
     desc: 新しいリリースタグを作成してプッシュ (VERSION=x.x.x)
     cmds:

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,8 +15,8 @@ import (
 
 type API struct {
 	Name string
-	Get  func(*http.Request, *Response) error
-	Post func(*http.Request, *Response) error
+	Get  func(context.Context, *http.Request, *Response) error
+	Post func(context.Context, *http.Request, *Response) error
 }
 
 type Response struct {
@@ -34,6 +35,7 @@ func New(cfg config.Config) ([]API, error) {
 
 func (api *API) MakeHundleFunc() (string, func(http.ResponseWriter, *http.Request)) {
 	return api.Name, func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		res := Response{
 			Status:  http.StatusOK,
 			Message: "OK",
@@ -42,9 +44,9 @@ func (api *API) MakeHundleFunc() (string, func(http.ResponseWriter, *http.Reques
 		var err error
 
 		if req.Method == http.MethodPost && api.Post != nil {
-			err = api.Post(req, &res)
+			err = api.Post(ctx, req, &res)
 		} else if req.Method == http.MethodGet && api.Get != nil {
-			err = api.Get(req, &res)
+			err = api.Get(ctx, req, &res)
 		} else {
 			// リクエストされたメソッドが用意されていない
 			res.Status = http.StatusMethodNotAllowed

--- a/api/line_hook.go
+++ b/api/line_hook.go
@@ -40,6 +40,9 @@ func makeLineHookAPI(cfg config.Config) API {
 
 func actByLineEvents(ctx context.Context, bot *linebot.LineBot, events []webhook.EventInterface) {
 	for _, event := range events {
+		if ctx.Err() != nil {
+			return
+		}
 		switch e := event.(type) {
 		case webhook.MessageEvent:
 			switch msg := e.Message.(type) {

--- a/api/line_hook.go
+++ b/api/line_hook.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net/http"
@@ -14,7 +15,7 @@ import (
 func makeLineHookAPI(cfg config.Config) API {
 	return API{
 		Name: "/callback",
-		Post: func(req *http.Request, res *Response) error {
+		Post: func(ctx context.Context, req *http.Request, res *Response) error {
 			bot, err := linebot.New(cfg)
 			if err != nil {
 				res.Status = http.StatusInternalServerError
@@ -31,19 +32,19 @@ func makeLineHookAPI(cfg config.Config) API {
 				return err
 			}
 
-			actByLineEvents(bot, cb.Events)
+			actByLineEvents(ctx, bot, cb.Events)
 			return nil
 		},
 	}
 }
 
-func actByLineEvents(bot *linebot.LineBot, events []webhook.EventInterface) {
+func actByLineEvents(ctx context.Context, bot *linebot.LineBot, events []webhook.EventInterface) {
 	for _, event := range events {
 		switch e := event.(type) {
 		case webhook.MessageEvent:
 			switch msg := e.Message.(type) {
 			case webhook.TextMessageContent:
-				tma := text_message_action.New(bot, e, msg)
+				tma := text_message_action.New(ctx, bot, e, msg)
 				tma.Do()
 			case webhook.ImageMessageContent:
 				log.Printf("[linebot.ActByEvents] ImageMessage")

--- a/api/message.go
+++ b/api/message.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -11,7 +12,7 @@ import (
 func makeMessageAPI(cfg config.Config) API {
 	return API{
 		Name: "/message",
-		Post: func(req *http.Request, res *Response) error {
+		Post: func(ctx context.Context, req *http.Request, res *Response) error {
 			bot, err := linebot.New(cfg)
 			if err != nil {
 				res.Status = http.StatusInternalServerError
@@ -34,7 +35,7 @@ func makeMessageAPI(cfg config.Config) API {
 				return fmt.Errorf("Token does not match")
 			}
 
-			err = bot.TextMessageWithRoomKey(parsedReq.Message, parsedReq.RoomKey)
+			err = bot.TextMessageWithRoomKey(ctx, parsedReq.Message, parsedReq.RoomKey)
 			if err != nil {
 				res.Status = http.StatusInternalServerError
 				return err

--- a/api/test.go
+++ b/api/test.go
@@ -1,6 +1,9 @@
 package api
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 var (
 	test = API{
@@ -9,7 +12,7 @@ var (
 	}
 )
 
-func getTest(req *http.Request, res *Response) error {
+func getTest(ctx context.Context, req *http.Request, res *Response) error {
 	res.Message = "this is test"
 	return nil
 }

--- a/app/alarm/alarm.go
+++ b/app/alarm/alarm.go
@@ -29,6 +29,9 @@ func New(bot *linebot.LineBot) *AlarmManager {
 func (am *AlarmManager) Run(ctx context.Context) error {
 
 	for _, a := range am.Alarms {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		chk, err := Check(&a, time_util.LocalTime(), constant.BaseMinuteDuration)
 		if err != nil {
 			log.Printf("[ID:%s] error: %s", a.ID, err)

--- a/app/alarm/alarm.go
+++ b/app/alarm/alarm.go
@@ -1,12 +1,13 @@
 package alarm
 
 import (
+	"context"
 	"log"
 
 	"github.com/commojun/nyanbot/app/linebot"
 	"github.com/commojun/nyanbot/app/time_util"
-	"github.com/commojun/nyanbot/masterdata"
 	"github.com/commojun/nyanbot/constant"
+	"github.com/commojun/nyanbot/masterdata"
 	"github.com/commojun/nyanbot/masterdata/table"
 )
 
@@ -25,7 +26,7 @@ func New(bot *linebot.LineBot) *AlarmManager {
 	return &am
 }
 
-func (am *AlarmManager) Run() error {
+func (am *AlarmManager) Run(ctx context.Context) error {
 
 	for _, a := range am.Alarms {
 		chk, err := Check(&a, time_util.LocalTime(), constant.BaseMinuteDuration)
@@ -36,7 +37,7 @@ func (am *AlarmManager) Run() error {
 		if chk == false {
 			continue
 		}
-		err = am.Bot.TextMessageWithRoomKey(a.Message, a.RoomKey)
+		err = am.Bot.TextMessageWithRoomKey(ctx, a.Message, a.RoomKey)
 		if err != nil {
 			log.Printf("[ID:%s] error: %s", a.ID, err)
 		}

--- a/app/anniversary/anniversary.go
+++ b/app/anniversary/anniversary.go
@@ -1,6 +1,7 @@
 package anniversary
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/rand"
@@ -32,7 +33,7 @@ func New(bot *linebot.LineBot) *AnniversaryManager {
 	return &am
 }
 
-func (am *AnniversaryManager) Run() error {
+func (am *AnniversaryManager) Run(ctx context.Context) error {
 	now := time_util.LocalTime()
 	for _, a := range am.Anniversaries {
 		msg, check, err := MakeCheckMessage(&a, now)
@@ -40,7 +41,7 @@ func (am *AnniversaryManager) Run() error {
 			return err
 		}
 		if check {
-			err := am.Bot.TextMessageWithRoomKey(msg, a.RoomKey)
+			err := am.Bot.TextMessageWithRoomKey(ctx, msg, a.RoomKey)
 			if err != nil {
 				return err
 			}

--- a/app/anniversary/anniversary.go
+++ b/app/anniversary/anniversary.go
@@ -36,6 +36,9 @@ func New(bot *linebot.LineBot) *AnniversaryManager {
 func (am *AnniversaryManager) Run(ctx context.Context) error {
 	now := time_util.LocalTime()
 	for _, a := range am.Anniversaries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		msg, check, err := MakeCheckMessage(&a, now)
 		if err != nil {
 			return err

--- a/app/hello/hello.go
+++ b/app/hello/hello.go
@@ -1,6 +1,8 @@
 package hello
 
 import (
+	"context"
+
 	"github.com/commojun/nyanbot/app/linebot"
 )
 
@@ -12,9 +14,9 @@ func New(bot *linebot.LineBot) *Hello {
 	return &Hello{Bot: bot}
 }
 
-func (hello *Hello) Say() error {
+func (hello *Hello) Say(ctx context.Context) error {
 
-	err := hello.Bot.TextMessage("Hello!")
+	err := hello.Bot.TextMessage(ctx, "Hello!")
 	if err != nil {
 		return err
 	}

--- a/app/linebot/linebot.go
+++ b/app/linebot/linebot.go
@@ -1,6 +1,8 @@
 package linebot
 
 import (
+	"context"
+
 	"github.com/commojun/nyanbot/config"
 	"github.com/commojun/nyanbot/masterdata"
 	"github.com/line/line-bot-sdk-go/v8/linebot/messaging_api"
@@ -25,28 +27,28 @@ func New(cfg config.Config) (*LineBot, error) {
 	}, nil
 }
 
-func (bot *LineBot) TextMessage(msg string) error {
-	return bot.TextMessageWithRoomID(msg, bot.DefaultRoomID)
+func (bot *LineBot) TextMessage(ctx context.Context, msg string) error {
+	return bot.TextMessageWithRoomID(ctx, msg, bot.DefaultRoomID)
 }
 
-func (bot *LineBot) TextMessageWithRoomKey(msg string, roomKey string) error {
+func (bot *LineBot) TextMessageWithRoomKey(ctx context.Context, msg string, roomKey string) error {
 	roomID, err := masterdata.GetKeyVals().RoomID(roomKey)
 	if err != nil {
 		return err
 	}
-	return bot.TextMessageWithRoomID(msg, roomID)
+	return bot.TextMessageWithRoomID(ctx, msg, roomID)
 }
 
-func (bot *LineBot) TextMessageWithRoomID(msg string, roomID string) error {
-	_, err := bot.Client.PushMessage(&messaging_api.PushMessageRequest{
+func (bot *LineBot) TextMessageWithRoomID(ctx context.Context, msg string, roomID string) error {
+	_, err := bot.Client.WithContext(ctx).PushMessage(&messaging_api.PushMessageRequest{
 		To:       roomID,
 		Messages: []messaging_api.MessageInterface{messaging_api.TextMessage{Text: msg}},
 	}, "")
 	return err
 }
 
-func (bot *LineBot) TextReply(msg string, replyToken string) error {
-	_, err := bot.Client.ReplyMessage(&messaging_api.ReplyMessageRequest{
+func (bot *LineBot) TextReply(ctx context.Context, msg string, replyToken string) error {
+	_, err := bot.Client.WithContext(ctx).ReplyMessage(&messaging_api.ReplyMessageRequest{
 		ReplyToken: replyToken,
 		Messages:   []messaging_api.MessageInterface{messaging_api.TextMessage{Text: msg}},
 	})

--- a/app/linebot/text_message_action/anniversary.go
+++ b/app/linebot/text_message_action/anniversary.go
@@ -17,7 +17,7 @@ func doRandomAnniversary(tma *TextMessageAction) error {
 		return err
 	}
 
-	err = tma.Bot.TextReply(msg, tma.Event.ReplyToken)
+	err = tma.Bot.TextReply(tma.Ctx, msg, tma.Event.ReplyToken)
 	if err != nil {
 		return err
 	}

--- a/app/linebot/text_message_action/fortune.go
+++ b/app/linebot/text_message_action/fortune.go
@@ -28,5 +28,5 @@ func doDrawFortune(tma *TextMessageAction) error {
 
 	msg := fmt.Sprintf("%sの今日の運勢\n>>>%s<<<", nickname, result)
 
-	return tma.Bot.TextReply(msg, tma.Event.ReplyToken)
+	return tma.Bot.TextReply(tma.Ctx, msg, tma.Event.ReplyToken)
 }

--- a/app/linebot/text_message_action/ojiline.go
+++ b/app/linebot/text_message_action/ojiline.go
@@ -34,5 +34,5 @@ func doOjisan(tma *TextMessageAction) error {
 		return err
 	}
 
-	return tma.Bot.TextReply(msg, tma.Event.ReplyToken)
+	return tma.Bot.TextReply(tma.Ctx, msg, tma.Event.ReplyToken)
 }

--- a/app/linebot/text_message_action/tell_id.go
+++ b/app/linebot/text_message_action/tell_id.go
@@ -23,5 +23,5 @@ func doTellID(tma *TextMessageAction) error {
 		replyText += fmt.Sprintf("このグループのID: %s\n", src.GroupId)
 	}
 	replyText += "だよ！"
-	return tma.Bot.TextReply(replyText, tma.Event.ReplyToken)
+	return tma.Bot.TextReply(tma.Ctx, replyText, tma.Event.ReplyToken)
 }

--- a/app/linebot/text_message_action/testdayo.go
+++ b/app/linebot/text_message_action/testdayo.go
@@ -8,7 +8,7 @@ var (
 )
 
 func doTest(tma *TextMessageAction) error {
-	err := tma.Bot.TextReply("これはテストへの返信だよ！！", tma.Event.ReplyToken)
+	err := tma.Bot.TextReply(tma.Ctx, "これはテストへの返信だよ！！", tma.Event.ReplyToken)
 	if err != nil {
 		return err
 	}

--- a/app/linebot/text_message_action/text_message_action.go
+++ b/app/linebot/text_message_action/text_message_action.go
@@ -1,6 +1,7 @@
 package text_message_action
 
 import (
+	"context"
 	"log"
 	"strings"
 
@@ -9,13 +10,15 @@ import (
 )
 
 type TextMessageAction struct {
+	Ctx     context.Context
 	Bot     *linebot.LineBot
 	Event   webhook.MessageEvent
 	Message webhook.TextMessageContent
 }
 
-func New(bot *linebot.LineBot, event webhook.MessageEvent, msg webhook.TextMessageContent) *TextMessageAction {
+func New(ctx context.Context, bot *linebot.LineBot, event webhook.MessageEvent, msg webhook.TextMessageContent) *TextMessageAction {
 	return &TextMessageAction{
+		Ctx:     ctx,
 		Bot:     bot,
 		Event:   event,
 		Message: msg,
@@ -64,7 +67,7 @@ func (tma *TextMessageAction) Do() {
 }
 
 func echo(tma *TextMessageAction) error {
-	err := tma.Bot.TextReply(tma.Message.Text, tma.Event.ReplyToken)
+	err := tma.Bot.TextReply(tma.Ctx, tma.Message.Text, tma.Event.ReplyToken)
 	if err != nil {
 		return err
 	}

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"context"
 	"log"
-	"strconv"
-
+	"net"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/commojun/nyanbot/api"
 	"github.com/commojun/nyanbot/config"
@@ -23,18 +25,42 @@ func New(cfg config.Config) (*Server, error) {
 	}, err
 }
 
-func (server *Server) Start() error {
+func (server *Server) Start(ctx context.Context) error {
+	mux := http.NewServeMux()
 	for _, api := range server.APIs {
 		newApi := api
-		http.HandleFunc(newApi.MakeHundleFunc())
+		mux.HandleFunc(newApi.MakeHundleFunc())
 		log.Printf("Registered API: %s", api.Name)
 	}
 
 	port := strconv.Itoa(server.Port)
-	log.Printf("Start server port:%s", port)
-	err := http.ListenAndServe(":"+port, nil)
-	if err != nil {
-		return err
+	httpSrv := &http.Server{
+		Addr:    ":" + port,
+		Handler: mux,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
 	}
-	return nil
+
+	errCh := make(chan error, 1)
+	go func() {
+		log.Printf("Start server port:%s", port)
+		errCh <- httpSrv.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Println("shutdown signal received, shutting down HTTP server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+		return nil
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	}
 }

--- a/app/sheet/sheet.go
+++ b/app/sheet/sheet.go
@@ -1,7 +1,8 @@
 package sheet
 
 import (
-	"golang.org/x/oauth2"
+	"context"
+
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/sheets/v4"
@@ -18,7 +19,7 @@ type Sheet struct {
 	Service *sheets.Service
 }
 
-func New(cfg Config) (*Sheet, error) {
+func New(ctx context.Context, cfg Config) (*Sheet, error) {
 	jwtCfg := &jwt.Config{
 		Email:        cfg.Email,
 		PrivateKey:   []byte(cfg.PrivateKey),
@@ -30,7 +31,7 @@ func New(cfg Config) (*Sheet, error) {
 		jwtCfg.TokenURL = google.JWTTokenURL
 	}
 
-	sheetService, err := sheets.New(jwtCfg.Client(oauth2.NoContext))
+	sheetService, err := sheets.New(jwtCfg.Client(ctx))
 	if err != nil {
 		return &Sheet{}, err
 	}
@@ -40,8 +41,8 @@ func New(cfg Config) (*Sheet, error) {
 	}, nil
 }
 
-func (sheet *Sheet) Get(spreadsheetID string, sheetName string) (*sheets.ValueRange, error) {
-	res, err := sheet.Service.Spreadsheets.Values.Get(spreadsheetID, sheetName).Do()
+func (sheet *Sheet) Get(ctx context.Context, spreadsheetID string, sheetName string) (*sheets.ValueRange, error) {
+	res, err := sheet.Service.Spreadsheets.Values.Get(spreadsheetID, sheetName).Context(ctx).Do()
 	if err != nil {
 		return &sheets.ValueRange{}, err
 	}

--- a/cmd/nyan/nyan.go
+++ b/cmd/nyan/nyan.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	"github.com/alecthomas/kong"
@@ -25,12 +26,13 @@ type CLI struct {
 // ServerCmd: HTTP サーバーを起動
 type ServerCmd struct{}
 
-func (cmd *ServerCmd) Run(ctx *CLI) error {
-	if err := masterdata.Initialize(ctx.Config); err != nil {
+func (cmd *ServerCmd) Run(cliCtx *CLI) error {
+	ctx := context.Background()
+	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
 		log.Fatal(err)
 	}
 
-	srv, err := server.New(ctx.Config)
+	srv, err := server.New(cliCtx.Config)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -41,52 +43,55 @@ func (cmd *ServerCmd) Run(ctx *CLI) error {
 // HelloCmd: テスト用 hello メッセージを送信
 type HelloCmd struct{}
 
-func (cmd *HelloCmd) Run(ctx *CLI) error {
-	if err := masterdata.Initialize(ctx.Config); err != nil {
+func (cmd *HelloCmd) Run(cliCtx *CLI) error {
+	ctx := context.Background()
+	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
 		log.Fatal(err)
 	}
 
-	bot, err := linebot.New(ctx.Config)
+	bot, err := linebot.New(cliCtx.Config)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	h := hello.New(bot)
-	return h.Say()
+	return h.Say(ctx)
 }
 
 // AlarmCmd: アラームチェッカーを実行
 type AlarmCmd struct{}
 
-func (cmd *AlarmCmd) Run(ctx *CLI) error {
-	if err := masterdata.Initialize(ctx.Config); err != nil {
+func (cmd *AlarmCmd) Run(cliCtx *CLI) error {
+	ctx := context.Background()
+	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
 		log.Fatal(err)
 	}
 
-	bot, err := linebot.New(ctx.Config)
+	bot, err := linebot.New(cliCtx.Config)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	alm := alarm.New(bot)
-	return alm.Run()
+	return alm.Run(ctx)
 }
 
 // AnniversaryCmd: 記念日チェッカーを実行
 type AnniversaryCmd struct{}
 
-func (cmd *AnniversaryCmd) Run(ctx *CLI) error {
-	if err := masterdata.Initialize(ctx.Config); err != nil {
+func (cmd *AnniversaryCmd) Run(cliCtx *CLI) error {
+	ctx := context.Background()
+	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
 		log.Fatal(err)
 	}
 
-	bot, err := linebot.New(ctx.Config)
+	bot, err := linebot.New(cliCtx.Config)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	anniv := anniversary.New(bot)
-	return anniv.Run()
+	return anniv.Run(ctx)
 }
 
 func main() {

--- a/cmd/nyan/nyan.go
+++ b/cmd/nyan/nyan.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/alecthomas/kong"
 	"github.com/commojun/nyanbot/app/alarm"
@@ -27,31 +31,35 @@ type CLI struct {
 type ServerCmd struct{}
 
 func (cmd *ServerCmd) Run(cliCtx *CLI) error {
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	srv, err := server.New(cliCtx.Config)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	return srv.Start()
+	return srv.Start(ctx)
 }
 
 // HelloCmd: テスト用 hello メッセージを送信
 type HelloCmd struct{}
 
 func (cmd *HelloCmd) Run(cliCtx *CLI) error {
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	bot, err := linebot.New(cliCtx.Config)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	h := hello.New(bot)
@@ -62,14 +70,16 @@ func (cmd *HelloCmd) Run(cliCtx *CLI) error {
 type AlarmCmd struct{}
 
 func (cmd *AlarmCmd) Run(cliCtx *CLI) error {
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	bot, err := linebot.New(cliCtx.Config)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	alm := alarm.New(bot)
@@ -80,14 +90,16 @@ func (cmd *AlarmCmd) Run(cliCtx *CLI) error {
 type AnniversaryCmd struct{}
 
 func (cmd *AnniversaryCmd) Run(cliCtx *CLI) error {
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	bot, err := linebot.New(cliCtx.Config)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	anniv := anniversary.New(bot)
@@ -96,7 +108,11 @@ func (cmd *AnniversaryCmd) Run(cliCtx *CLI) error {
 
 func main() {
 	var cli CLI
-	ctx := kong.Parse(&cli)
-	err := ctx.Run(&cli)
-	ctx.FatalIfErrorf(err)
+	kongCtx := kong.Parse(&cli)
+	err := kongCtx.Run(&cli)
+	if errors.Is(err, context.Canceled) {
+		log.Println("received shutdown signal, exiting normally")
+		return
+	}
+	kongCtx.FatalIfErrorf(err)
 }

--- a/cmd/nyan/nyan.go
+++ b/cmd/nyan/nyan.go
@@ -30,10 +30,7 @@ type CLI struct {
 // ServerCmd: HTTP サーバーを起動
 type ServerCmd struct{}
 
-func (cmd *ServerCmd) Run(cliCtx *CLI) error {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
+func (cmd *ServerCmd) Run(ctx context.Context, cliCtx *CLI) error {
 	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
 		return err
 	}
@@ -49,10 +46,7 @@ func (cmd *ServerCmd) Run(cliCtx *CLI) error {
 // HelloCmd: テスト用 hello メッセージを送信
 type HelloCmd struct{}
 
-func (cmd *HelloCmd) Run(cliCtx *CLI) error {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
+func (cmd *HelloCmd) Run(ctx context.Context, cliCtx *CLI) error {
 	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
 		return err
 	}
@@ -69,10 +63,7 @@ func (cmd *HelloCmd) Run(cliCtx *CLI) error {
 // AlarmCmd: アラームチェッカーを実行
 type AlarmCmd struct{}
 
-func (cmd *AlarmCmd) Run(cliCtx *CLI) error {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
+func (cmd *AlarmCmd) Run(ctx context.Context, cliCtx *CLI) error {
 	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
 		return err
 	}
@@ -89,10 +80,7 @@ func (cmd *AlarmCmd) Run(cliCtx *CLI) error {
 // AnniversaryCmd: 記念日チェッカーを実行
 type AnniversaryCmd struct{}
 
-func (cmd *AnniversaryCmd) Run(cliCtx *CLI) error {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
+func (cmd *AnniversaryCmd) Run(ctx context.Context, cliCtx *CLI) error {
 	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
 		return err
 	}
@@ -107,9 +95,12 @@ func (cmd *AnniversaryCmd) Run(cliCtx *CLI) error {
 }
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	var cli CLI
 	kongCtx := kong.Parse(&cli)
-	err := kongCtx.Run(&cli)
+	err := kongCtx.Run(ctx, &cli)
 	if errors.Is(err, context.Canceled) {
 		log.Println("received shutdown signal, exiting normally")
 		return

--- a/envfile.sample
+++ b/envfile.sample
@@ -1,6 +1,5 @@
 NYAN_SERVER_PORT=portnum
 NYAN_MESSAGE_TOKEN=token
-NYAN_REDIS_HOST=redis:6379
 
 NYAN_CHANNEL_SECRET=line_channel_secret
 NYAN_ACCESS_TOKEN=line_access_token

--- a/masterdata/key_value/key_value.go
+++ b/masterdata/key_value/key_value.go
@@ -1,6 +1,7 @@
 package key_value
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -14,19 +15,19 @@ var (
 )
 
 type KVs struct {
-	Rooms    map[string]string `kvName:"room"`
+	Rooms     map[string]string `kvName:"room"`
 	Nicknames map[string]string `kvName:"nickname"`
-	Tests    map[string]string `kvName:"testkv"`
+	Tests     map[string]string `kvName:"testkv"`
 }
 
-func LoadKVsFromSheet(s *sheet.Sheet, sheetID string) (*KVs, error) {
+func LoadKVsFromSheet(ctx context.Context, s *sheet.Sheet, sheetID string) (*KVs, error) {
 	kvs := &KVs{}
 
 	kvsType := reflect.TypeOf(*kvs)
 	for i := 0; i < kvsType.NumField(); i++ {
 		// kvを作成
 		kvName := kvsType.Field(i).Tag.Get("kvName")
-		kv, err := getKVFromSheet(s, kvName, sheetID)
+		kv, err := getKVFromSheet(ctx, s, kvName, sheetID)
 		if err != nil {
 			return nil, err
 		}
@@ -37,9 +38,9 @@ func LoadKVsFromSheet(s *sheet.Sheet, sheetID string) (*KVs, error) {
 	return kvs, nil
 }
 
-func getKVFromSheet(s *sheet.Sheet, kvName string, sheetID string) (*map[string]string, error) {
+func getKVFromSheet(ctx context.Context, s *sheet.Sheet, kvName string, sheetID string) (*map[string]string, error) {
 	// シートからデータを取得
-	res, err := s.Get(sheetID, kvName)
+	res, err := s.Get(ctx, sheetID, kvName)
 	if err != nil {
 		return &map[string]string{}, err
 	}

--- a/masterdata/masterdata.go
+++ b/masterdata/masterdata.go
@@ -30,7 +30,7 @@ func Initialize(ctx context.Context, cfg config.Config) error {
 	}
 
 	var md *MasterData
-	err := retry.Retry(3, 2*time.Second, func() error {
+	err := retry.WithContext(ctx, 3, 2*time.Second, func() error {
 		log.Println("Attempting to load data from Google Sheets...")
 		m, err := loadFromSheet(ctx, cfg)
 		if err != nil {
@@ -42,7 +42,7 @@ func Initialize(ctx context.Context, cfg config.Config) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to initialize masterdata after 3 retries: %w", err)
+		return fmt.Errorf("failed to initialize masterdata: %w", err)
 	}
 
 	global = md

--- a/masterdata/masterdata.go
+++ b/masterdata/masterdata.go
@@ -1,6 +1,7 @@
 package masterdata
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -23,7 +24,7 @@ type MasterData struct {
 }
 
 // Initialize: Pod起動時に一度だけ呼ばれる（リトライあり）
-func Initialize(cfg config.Config) error {
+func Initialize(ctx context.Context, cfg config.Config) error {
 	if global != nil {
 		return nil // 既に初期化済み
 	}
@@ -31,7 +32,7 @@ func Initialize(cfg config.Config) error {
 	var md *MasterData
 	err := retry.Retry(3, 2*time.Second, func() error {
 		log.Println("Attempting to load data from Google Sheets...")
-		m, err := loadFromSheet(cfg)
+		m, err := loadFromSheet(ctx, cfg)
 		if err != nil {
 			log.Printf("Failed to load from Google Sheets: %v", err)
 			return err
@@ -49,8 +50,8 @@ func Initialize(cfg config.Config) error {
 	return nil
 }
 
-func loadFromSheet(cfg config.Config) (*MasterData, error) {
-	s, err := sheet.New(sheet.Config{
+func loadFromSheet(ctx context.Context, cfg config.Config) (*MasterData, error) {
+	s, err := sheet.New(ctx, sheet.Config{
 		Email:        cfg.GoogleClientEmail,
 		PrivateKey:   strings.ReplaceAll(cfg.GooglePrivateKey, `\n`, "\n"),
 		PrivateKeyID: cfg.GooglePrivateKeyID,
@@ -60,12 +61,12 @@ func loadFromSheet(cfg config.Config) (*MasterData, error) {
 		return nil, fmt.Errorf("failed to create sheet service: %w", err)
 	}
 
-	tables, err := table.LoadTablesFromSheet(s, cfg.SheetID)
+	tables, err := table.LoadTablesFromSheet(ctx, s, cfg.SheetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tables: %w", err)
 	}
 
-	kvs, err := key_value.LoadKVsFromSheet(s, cfg.SheetID)
+	kvs, err := key_value.LoadKVsFromSheet(ctx, s, cfg.SheetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load key-values: %w", err)
 	}

--- a/masterdata/table/table.go
+++ b/masterdata/table/table.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/commojun/nyanbot/app/sheet"
@@ -11,7 +12,7 @@ type Tables struct {
 	Anniversaries []Anniversary `tableName:"anniversary"`
 }
 
-func LoadTablesFromSheet(s *sheet.Sheet, sheetID string) (*Tables, error) {
+func LoadTablesFromSheet(ctx context.Context, s *sheet.Sheet, sheetID string) (*Tables, error) {
 	ts := &Tables{}
 
 	tsType := reflect.TypeOf(*ts)
@@ -19,7 +20,7 @@ func LoadTablesFromSheet(s *sheet.Sheet, sheetID string) (*Tables, error) {
 		// tableを生成
 		tName := tsType.Field(i).Tag.Get("tableName")
 		tType := tsType.Field(i).Type
-		tValue, err := getTableFromSheet(s, tType, tName, sheetID)
+		tValue, err := getTableFromSheet(ctx, s, tType, tName, sheetID)
 		if err != nil {
 			return nil, err
 		}
@@ -30,9 +31,9 @@ func LoadTablesFromSheet(s *sheet.Sheet, sheetID string) (*Tables, error) {
 	return ts, nil
 }
 
-func getTableFromSheet(s *sheet.Sheet, tType reflect.Type, tName string, sheetID string) (reflect.Value, error) {
+func getTableFromSheet(ctx context.Context, s *sheet.Sheet, tType reflect.Type, tName string, sheetID string) (reflect.Value, error) {
 	// シートからデータを取得
-	res, err := s.Get(sheetID, tName)
+	res, err := s.Get(ctx, sheetID, tName)
 	if err != nil {
 		return reflect.Value{}, err
 	}


### PR DESCRIPTION
関連Issue: https://github.com/commojun/nyanbot/issues/19

## 概要

PR #23（LINE SDK v8移行）完了後の最新コードを踏まえ、`context.Context` をアプリ全体に伝播させた。
`oauth2.NoContext` の除去・LINE SDK v8 の `WithContext(ctx)` 活用・HTTP層からバックグラウンド処理まで一気通貫で対応。

## 変更点

- `app/sheet/sheet.go`: `New(ctx, cfg)` / `Get(ctx, ...)` に ctx 追加、`oauth2.NoContext` を ctx に置き換え
- `masterdata/masterdata.go`: `Initialize(ctx, cfg)` / `loadFromSheet(ctx, cfg)` に ctx 追加
- `masterdata/table/table.go`: `LoadTablesFromSheet(ctx, ...)` / `getTableFromSheet(ctx, ...)` に ctx 追加
- `masterdata/key_value/key_value.go`: `LoadKVsFromSheet(ctx, ...)` / `getKVFromSheet(ctx, ...)` に ctx 追加
- `api/api.go`: `Get`/`Post` 関数型定義に `context.Context` を追加、`MakeHundleFunc` 内で `r.Context()` を取り出して伝播
- `api/test.go`, `api/line_hook.go`, `api/message.go`: ハンドラー関数シグネチャを ctx 対応に更新
- `app/linebot/linebot.go`: 全公開メソッドに ctx 追加、LINE SDK v8 の `WithContext(ctx)` でメッセージ送信に ctx を活用
- `app/linebot/text_message_action/text_message_action.go`: `TextMessageAction` 構造体に `Ctx` フィールドを追加、`New(ctx, ...)` にctx追加
- `app/linebot/text_message_action/` 各ファイル: `tma.Ctx` を使って `Bot.TextReply` を呼ぶよう更新
- `app/alarm/alarm.go`: `Run(ctx)` に ctx 追加
- `app/anniversary/anniversary.go`: `Run(ctx)` に ctx 追加
- `app/hello/hello.go`: `Say(ctx)` に ctx 追加
- `cmd/nyan/nyan.go`: kong の `ctx *CLI` 引数を `cliCtx *CLI` にリネームして名前衝突を回避、各コマンドで `context.Background()` を生成して伝播