### PR TITLE
Issue#24: テストを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v5
+      -
+        name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+      -
+        name: Run tests
+        run: go test ./...

--- a/api/line_hook.go
+++ b/api/line_hook.go
@@ -12,6 +12,11 @@ import (
 	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
 )
 
+type LineBot interface {
+	ParseWebhookRequest(req *http.Request) (*webhook.CallbackRequest, error)
+	TextReply(ctx context.Context, msg string, replyToken string) error
+}
+
 func makeLineHookAPI(cfg config.Config) API {
 	return API{
 		Name: "/callback",
@@ -22,7 +27,7 @@ func makeLineHookAPI(cfg config.Config) API {
 				return err
 			}
 
-			cb, err := webhook.ParseRequest(bot.ChannelSecret, req)
+			cb, err := bot.ParseWebhookRequest(req)
 			if err != nil {
 				if errors.Is(err, webhook.ErrInvalidSignature) {
 					res.Status = http.StatusBadRequest
@@ -38,7 +43,7 @@ func makeLineHookAPI(cfg config.Config) API {
 	}
 }
 
-func actByLineEvents(ctx context.Context, bot *linebot.LineBot, events []webhook.EventInterface) {
+func actByLineEvents(ctx context.Context, bot LineBot, events []webhook.EventInterface) {
 	for _, event := range events {
 		if ctx.Err() != nil {
 			return
@@ -47,8 +52,8 @@ func actByLineEvents(ctx context.Context, bot *linebot.LineBot, events []webhook
 		case webhook.MessageEvent:
 			switch msg := e.Message.(type) {
 			case webhook.TextMessageContent:
-				tma := text_message_action.New(ctx, bot, e, msg)
-				tma.Do()
+				tma := text_message_action.New(bot, e, msg)
+				tma.Do(ctx)
 			case webhook.ImageMessageContent:
 				log.Printf("[linebot.ActByEvents] ImageMessage")
 			default:

--- a/api/line_hook.go
+++ b/api/line_hook.go
@@ -26,21 +26,24 @@ func makeLineHookAPI(cfg config.Config) API {
 				res.Status = http.StatusInternalServerError
 				return err
 			}
-
-			cb, err := bot.ParseWebhookRequest(req)
-			if err != nil {
-				if errors.Is(err, webhook.ErrInvalidSignature) {
-					res.Status = http.StatusBadRequest
-				} else {
-					res.Status = http.StatusInternalServerError
-				}
-				return err
-			}
-
-			actByLineEvents(ctx, bot, cb.Events)
-			return nil
+			return handleCallback(ctx, bot, req, res)
 		},
 	}
+}
+
+func handleCallback(ctx context.Context, bot LineBot, req *http.Request, res *Response) error {
+	cb, err := bot.ParseWebhookRequest(req)
+	if err != nil {
+		if errors.Is(err, webhook.ErrInvalidSignature) {
+			res.Status = http.StatusBadRequest
+		} else {
+			res.Status = http.StatusInternalServerError
+		}
+		return err
+	}
+
+	actByLineEvents(ctx, bot, cb.Events)
+	return nil
 }
 
 func actByLineEvents(ctx context.Context, bot LineBot, events []webhook.EventInterface) {

--- a/api/line_hook_test.go
+++ b/api/line_hook_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
+)
+
+type mockLineBot struct {
+	parseResult *webhook.CallbackRequest
+	parseErr    error
+	replies     []replyCall
+}
+
+type replyCall struct {
+	msg        string
+	replyToken string
+}
+
+func (m *mockLineBot) ParseWebhookRequest(req *http.Request) (*webhook.CallbackRequest, error) {
+	return m.parseResult, m.parseErr
+}
+
+func (m *mockLineBot) TextReply(ctx context.Context, msg string, replyToken string) error {
+	m.replies = append(m.replies, replyCall{msg: msg, replyToken: replyToken})
+	return nil
+}
+
+func newTestRequest() *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/callback", strings.NewReader(""))
+}
+
+// --- handleCallback tests ---
+
+func TestHandleCallback_Success(t *testing.T) {
+	bot := &mockLineBot{
+		parseResult: &webhook.CallbackRequest{
+			Events: []webhook.EventInterface{
+				webhook.MessageEvent{
+					ReplyToken: "tk-1",
+					Source:     webhook.UserSource{UserId: "U-x"},
+					Message:    webhook.TextMessageContent{Id: "m1", Text: "てすと"},
+				},
+			},
+		},
+	}
+	res := &Response{Status: http.StatusOK, Message: "OK"}
+
+	err := handleCallback(context.Background(), bot, newTestRequest(), res)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if res.Status != http.StatusOK {
+		t.Errorf("status = %d, want %d", res.Status, http.StatusOK)
+	}
+	// TMA 経由で TextReply が呼ばれてる
+	if len(bot.replies) != 1 {
+		t.Errorf("TextReply 呼び出し回数 = %d, want 1", len(bot.replies))
+	}
+}
+
+func TestHandleCallback_InvalidSignature(t *testing.T) {
+	bot := &mockLineBot{
+		parseErr: webhook.ErrInvalidSignature,
+	}
+	res := &Response{Status: http.StatusOK, Message: "OK"}
+
+	err := handleCallback(context.Background(), bot, newTestRequest(), res)
+	if err == nil {
+		t.Fatal("エラーが返るべきだが nil だった")
+	}
+	if res.Status != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", res.Status, http.StatusBadRequest)
+	}
+	if len(bot.replies) != 0 {
+		t.Errorf("不正署名時は reply されないべきだが %d 回呼ばれた", len(bot.replies))
+	}
+}
+
+func TestHandleCallback_OtherParseError(t *testing.T) {
+	bot := &mockLineBot{
+		parseErr: errors.New("some other error"),
+	}
+	res := &Response{Status: http.StatusOK, Message: "OK"}
+
+	err := handleCallback(context.Background(), bot, newTestRequest(), res)
+	if err == nil {
+		t.Fatal("エラーが返るべきだが nil だった")
+	}
+	if res.Status != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", res.Status, http.StatusInternalServerError)
+	}
+}
+
+// --- actByLineEvents tests ---
+
+func TestActByLineEvents_EmptyEvents(t *testing.T) {
+	bot := &mockLineBot{}
+	actByLineEvents(context.Background(), bot, nil)
+	if len(bot.replies) != 0 {
+		t.Errorf("空イベントリストでは reply されないべき")
+	}
+}
+
+func TestActByLineEvents_TextMessage(t *testing.T) {
+	bot := &mockLineBot{}
+	events := []webhook.EventInterface{
+		webhook.MessageEvent{
+			ReplyToken: "tk-1",
+			Source:     webhook.UserSource{UserId: "U-x"},
+			Message:    webhook.TextMessageContent{Id: "m1", Text: "てすと"},
+		},
+	}
+
+	actByLineEvents(context.Background(), bot, events)
+
+	if len(bot.replies) != 1 {
+		t.Fatalf("TextReply 呼び出し回数 = %d, want 1", len(bot.replies))
+	}
+	if bot.replies[0].replyToken != "tk-1" {
+		t.Errorf("replyToken = %q, want %q", bot.replies[0].replyToken, "tk-1")
+	}
+}
+
+func TestActByLineEvents_ImageMessage_NoReply(t *testing.T) {
+	bot := &mockLineBot{}
+	events := []webhook.EventInterface{
+		webhook.MessageEvent{
+			ReplyToken: "tk-img",
+			Source:     webhook.UserSource{UserId: "U-x"},
+			Message:    webhook.ImageMessageContent{Id: "img-1"},
+		},
+	}
+
+	actByLineEvents(context.Background(), bot, events)
+
+	if len(bot.replies) != 0 {
+		t.Errorf("画像メッセージは reply されないべきだが %d 回呼ばれた", len(bot.replies))
+	}
+}
+
+func TestActByLineEvents_CancelledContext(t *testing.T) {
+	bot := &mockLineBot{}
+	events := []webhook.EventInterface{
+		webhook.MessageEvent{
+			ReplyToken: "tk-1",
+			Source:     webhook.UserSource{UserId: "U-x"},
+			Message:    webhook.TextMessageContent{Id: "m1", Text: "てすと"},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	actByLineEvents(ctx, bot, events)
+
+	if len(bot.replies) != 0 {
+		t.Errorf("キャンセル済み ctx では処理されないべきだが %d 回呼ばれた", len(bot.replies))
+	}
+}
+
+func TestActByLineEvents_StopsOnMidwayCancel(t *testing.T) {
+	// 最初の1件は処理され、途中で ctx キャンセルすると後続はスキップされる
+	// → 完全な確定検証は難しいが、事前キャンセルで 0 件、キャンセルなしで2件になることで
+	//   イテレーション毎のチェックが機能してることを確認できる
+	bot := &mockLineBot{}
+	events := []webhook.EventInterface{
+		webhook.MessageEvent{
+			ReplyToken: "tk-1",
+			Source:     webhook.UserSource{UserId: "U-x"},
+			Message:    webhook.TextMessageContent{Id: "m1", Text: "てすと"},
+		},
+		webhook.MessageEvent{
+			ReplyToken: "tk-2",
+			Source:     webhook.UserSource{UserId: "U-y"},
+			Message:    webhook.TextMessageContent{Id: "m2", Text: "てすと"},
+		},
+	}
+
+	actByLineEvents(context.Background(), bot, events)
+
+	if len(bot.replies) != 2 {
+		t.Errorf("2件とも処理されるべきだが %d 件だった", len(bot.replies))
+	}
+}

--- a/app/alarm/alarm.go
+++ b/app/alarm/alarm.go
@@ -4,19 +4,22 @@ import (
 	"context"
 	"log"
 
-	"github.com/commojun/nyanbot/app/linebot"
 	"github.com/commojun/nyanbot/app/time_util"
 	"github.com/commojun/nyanbot/constant"
 	"github.com/commojun/nyanbot/masterdata"
 	"github.com/commojun/nyanbot/masterdata/table"
 )
 
-type AlarmManager struct {
-	Alarms []table.Alarm
-	Bot    *linebot.LineBot
+type LineBot interface {
+	TextMessageWithRoomKey(ctx context.Context, msg string, roomKey string) error
 }
 
-func New(bot *linebot.LineBot) *AlarmManager {
+type AlarmManager struct {
+	Alarms []table.Alarm
+	Bot    LineBot
+}
+
+func New(bot LineBot) *AlarmManager {
 	alms := masterdata.GetTables().Alarms
 
 	am := AlarmManager{

--- a/app/alarm/alarm_test.go
+++ b/app/alarm/alarm_test.go
@@ -111,6 +111,43 @@ func TestAlarmManager_Run_SkipsNonMatchingAlarm(t *testing.T) {
 	}
 }
 
+func TestAlarmManager_Run_MixedMatchNonMatch(t *testing.T) {
+	// マッチ/非マッチを混ぜた時に、マッチした分だけ送信され順序も保たれる
+	nonMatching := table.Alarm{
+		ID:         "2",
+		Month:      "13", // 絶対にマッチしない
+		WeekNum:    "*",
+		DayOfWeek:  "*",
+		DayOfMonth: "*",
+		Hour:       "*",
+		Minute:     "*",
+		Message:    "never",
+		RoomKey:    "roomX",
+	}
+	bot := &mockBot{}
+	am := &AlarmManager{
+		Alarms: []table.Alarm{
+			wildcardAlarm("1", "first", "roomA"),
+			nonMatching,
+			wildcardAlarm("3", "third", "roomC"),
+		},
+		Bot: bot,
+	}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(bot.sent) != 2 {
+		t.Fatalf("マッチ2件のみ送信されるべきだが %d 件だった", len(bot.sent))
+	}
+	if bot.sent[0].msg != "first" || bot.sent[0].roomKey != "roomA" {
+		t.Errorf("1件目が不正: %+v", bot.sent[0])
+	}
+	if bot.sent[1].msg != "third" || bot.sent[1].roomKey != "roomC" {
+		t.Errorf("2件目が不正: %+v", bot.sent[1])
+	}
+}
+
 func TestAlarmManager_Run_ContinuesOnBotError(t *testing.T) {
 	// Bot がエラーを返してもループは継続する（現仕様）
 	bot := &mockBot{err: errors.New("bot error")}

--- a/app/alarm/alarm_test.go
+++ b/app/alarm/alarm_test.go
@@ -1,0 +1,131 @@
+package alarm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/commojun/nyanbot/masterdata/table"
+)
+
+type mockBot struct {
+	sent []sentMsg
+	err  error
+}
+
+type sentMsg struct {
+	msg     string
+	roomKey string
+}
+
+func (m *mockBot) TextMessageWithRoomKey(ctx context.Context, msg string, roomKey string) error {
+	m.sent = append(m.sent, sentMsg{msg: msg, roomKey: roomKey})
+	return m.err
+}
+
+// wildcardAlarm: すべての時刻フィールドが "*" で常時マッチするアラーム
+func wildcardAlarm(id, message, roomKey string) table.Alarm {
+	return table.Alarm{
+		ID:         id,
+		Month:      "*",
+		WeekNum:    "*",
+		DayOfWeek:  "*",
+		DayOfMonth: "*",
+		Hour:       "*",
+		Minute:     "*",
+		Message:    message,
+		RoomKey:    roomKey,
+	}
+}
+
+func TestAlarmManager_Run_EmptyAlarms(t *testing.T) {
+	bot := &mockBot{}
+	am := &AlarmManager{Alarms: nil, Bot: bot}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(bot.sent) != 0 {
+		t.Errorf("送信回数は 0 であるべきだが %d だった", len(bot.sent))
+	}
+}
+
+func TestAlarmManager_Run_CancelledContext(t *testing.T) {
+	bot := &mockBot{}
+	am := &AlarmManager{
+		Alarms: []table.Alarm{wildcardAlarm("1", "msg1", "room1")},
+		Bot:    bot,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := am.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("context.Canceled が返るべきだが %v だった", err)
+	}
+	if len(bot.sent) != 0 {
+		t.Errorf("キャンセル済み ctx では送信されないべきだが %d 件送信された", len(bot.sent))
+	}
+}
+
+func TestAlarmManager_Run_SendsWildcardAlarm(t *testing.T) {
+	bot := &mockBot{}
+	am := &AlarmManager{
+		Alarms: []table.Alarm{wildcardAlarm("1", "hello", "roomA")},
+		Bot:    bot,
+	}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(bot.sent) != 1 {
+		t.Fatalf("送信回数は 1 であるべきだが %d だった", len(bot.sent))
+	}
+	if bot.sent[0].msg != "hello" || bot.sent[0].roomKey != "roomA" {
+		t.Errorf("送信内容が不正: %+v", bot.sent[0])
+	}
+}
+
+func TestAlarmManager_Run_SkipsNonMatchingAlarm(t *testing.T) {
+	// Month=13 は存在しないので絶対にマッチしない
+	nonMatching := table.Alarm{
+		ID:         "1",
+		Month:      "13",
+		WeekNum:    "*",
+		DayOfWeek:  "*",
+		DayOfMonth: "*",
+		Hour:       "*",
+		Minute:     "*",
+		Message:    "never",
+		RoomKey:    "roomX",
+	}
+	bot := &mockBot{}
+	am := &AlarmManager{Alarms: []table.Alarm{nonMatching}, Bot: bot}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(bot.sent) != 0 {
+		t.Errorf("マッチしないアラームは送信されないべきだが %d 件送信された", len(bot.sent))
+	}
+}
+
+func TestAlarmManager_Run_ContinuesOnBotError(t *testing.T) {
+	// Bot がエラーを返してもループは継続する（現仕様）
+	bot := &mockBot{err: errors.New("bot error")}
+	am := &AlarmManager{
+		Alarms: []table.Alarm{
+			wildcardAlarm("1", "msg1", "room1"),
+			wildcardAlarm("2", "msg2", "room2"),
+		},
+		Bot: bot,
+	}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("Bot エラーは握り潰されるべきだが Run が %v を返した", err)
+	}
+	if len(bot.sent) != 2 {
+		t.Errorf("エラーでも後続の送信は実行されるべきだが %d 件だった", len(bot.sent))
+	}
+}

--- a/app/anniversary/anniversary.go
+++ b/app/anniversary/anniversary.go
@@ -8,22 +8,25 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/commojun/nyanbot/app/linebot"
 	"github.com/commojun/nyanbot/app/time_util"
 	"github.com/commojun/nyanbot/masterdata"
 	"github.com/commojun/nyanbot/masterdata/table"
 )
 
+type LineBot interface {
+	TextMessageWithRoomKey(ctx context.Context, msg string, roomKey string) error
+}
+
 type AnniversaryManager struct {
 	Anniversaries []table.Anniversary
-	Bot           *linebot.LineBot
+	Bot           LineBot
 }
 
 var (
 	TEMPLATE = "今日は%sから%d%sだよ！"
 )
 
-func New(bot *linebot.LineBot) *AnniversaryManager {
+func New(bot LineBot) *AnniversaryManager {
 	annivs := masterdata.GetTables().Anniversaries
 
 	am := AnniversaryManager{
@@ -55,9 +58,14 @@ func (am *AnniversaryManager) Run(ctx context.Context) error {
 	return nil
 }
 
-func (am *AnniversaryManager) RandomMsg() (string, error) {
+func RandomMsg() (string, error) {
+	annivs := masterdata.GetTables().Anniversaries
+	if len(annivs) == 0 {
+		return "", fmt.Errorf("no anniversaries available")
+	}
+
 	rand.Seed(time.Now().UnixNano())
-	a := am.Anniversaries[rand.Intn(len(am.Anniversaries))]
+	a := annivs[rand.Intn(len(annivs))]
 
 	msg, _, err := MakeCheckMessage(&a, time_util.LocalTime())
 	if err != nil {

--- a/app/anniversary/anniversary_test.go
+++ b/app/anniversary/anniversary_test.go
@@ -1,12 +1,30 @@
 package anniversary
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/commojun/nyanbot/app/time_util"
 	"github.com/commojun/nyanbot/masterdata/table"
 )
+
+type mockBot struct {
+	sent []sentMsg
+	err  error
+}
+
+type sentMsg struct {
+	msg     string
+	roomKey string
+}
+
+func (m *mockBot) TextMessageWithRoomKey(ctx context.Context, msg string, roomKey string) error {
+	m.sent = append(m.sent, sentMsg{msg: msg, roomKey: roomKey})
+	return m.err
+}
 
 var jst = time.FixedZone("JST", 9*60*60)
 
@@ -120,4 +138,147 @@ func TestMakeCheckMessage(t *testing.T) {
 			t.Error("エラーが返るべきだが nil だった")
 		}
 	})
+}
+
+func TestAnniversaryManager_Run_EmptyList(t *testing.T) {
+	bot := &mockBot{}
+	am := &AnniversaryManager{Anniversaries: nil, Bot: bot}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(bot.sent) != 0 {
+		t.Errorf("送信回数は 0 であるべきだが %d だった", len(bot.sent))
+	}
+}
+
+func TestAnniversaryManager_Run_CancelledContext(t *testing.T) {
+	bot := &mockBot{}
+	// 今日と同じ月日の記念日 → check=true で送信対象になる
+	today := time_util.LocalTime()
+	am := &AnniversaryManager{
+		Anniversaries: []table.Anniversary{
+			{
+				ID:      "1",
+				Date:    today.Format("2006-01-02"),
+				Period:  "100",
+				Name:    "テスト",
+				RoomKey: "room1",
+			},
+		},
+		Bot: bot,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := am.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("context.Canceled が返るべきだが %v だった", err)
+	}
+	if len(bot.sent) != 0 {
+		t.Errorf("キャンセル済み ctx では送信されないべきだが %d 件送信された", len(bot.sent))
+	}
+}
+
+func TestAnniversaryManager_Run_SendsOnMatch(t *testing.T) {
+	bot := &mockBot{}
+	today := time_util.LocalTime()
+	// 今日と同じ月日（n年前）の記念日 → check=true
+	pastDate := time.Date(today.Year()-3, today.Month(), today.Day(), 0, 0, 0, 0, today.Location())
+	am := &AnniversaryManager{
+		Anniversaries: []table.Anniversary{
+			{
+				ID:      "1",
+				Date:    pastDate.Format("2006-01-02"),
+				Period:  "100",
+				Name:    "三周年",
+				RoomKey: "roomA",
+			},
+		},
+		Bot: bot,
+	}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(bot.sent) != 1 {
+		t.Fatalf("送信回数は 1 であるべきだが %d だった", len(bot.sent))
+	}
+	if bot.sent[0].roomKey != "roomA" {
+		t.Errorf("roomKey 不正: got %q", bot.sent[0].roomKey)
+	}
+}
+
+func TestAnniversaryManager_Run_SkipsOnNoMatch(t *testing.T) {
+	bot := &mockBot{}
+	today := time_util.LocalTime()
+	// 昨日の日付 + Period=9999 → check=false
+	yesterday := today.AddDate(0, 0, -1)
+	am := &AnniversaryManager{
+		Anniversaries: []table.Anniversary{
+			{
+				ID:      "1",
+				Date:    yesterday.Format("2006-01-02"),
+				Period:  "9999",
+				Name:    "昨日",
+				RoomKey: "roomB",
+			},
+		},
+		Bot: bot,
+	}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(bot.sent) != 0 {
+		t.Errorf("マッチしない日は送信されないべきだが %d 件送信された", len(bot.sent))
+	}
+}
+
+func TestAnniversaryManager_Run_PropagatesBotError(t *testing.T) {
+	botErr := errors.New("bot failure")
+	bot := &mockBot{err: botErr}
+	today := time_util.LocalTime()
+	am := &AnniversaryManager{
+		Anniversaries: []table.Anniversary{
+			{
+				ID:      "1",
+				Date:    today.Format("2006-01-02"),
+				Period:  "100",
+				Name:    "本日",
+				RoomKey: "roomC",
+			},
+		},
+		Bot: bot,
+	}
+
+	err := am.Run(context.Background())
+	if !errors.Is(err, botErr) {
+		t.Errorf("bot エラーが伝播するべきだが %v だった", err)
+	}
+}
+
+func TestAnniversaryManager_Run_PropagatesMakeMessageError(t *testing.T) {
+	bot := &mockBot{}
+	am := &AnniversaryManager{
+		Anniversaries: []table.Anniversary{
+			{
+				ID:      "1",
+				Date:    "invalid-date",
+				Period:  "100",
+				Name:    "壊れた記念日",
+				RoomKey: "roomD",
+			},
+		},
+		Bot: bot,
+	}
+
+	err := am.Run(context.Background())
+	if err == nil {
+		t.Error("MakeCheckMessage エラーが伝播するべきだが nil だった")
+	}
+	if len(bot.sent) != 0 {
+		t.Errorf("エラー時は送信されないべきだが %d 件送信された", len(bot.sent))
+	}
 }

--- a/app/anniversary/anniversary_test.go
+++ b/app/anniversary/anniversary_test.go
@@ -236,6 +236,39 @@ func TestAnniversaryManager_Run_SkipsOnNoMatch(t *testing.T) {
 	}
 }
 
+func TestAnniversaryManager_Run_MixedMatchAndNoMatch(t *testing.T) {
+	// 3件の記念日を用意:
+	// 1: 今日と同じ月日 (match)
+	// 2: 昨日 + Period=9999 (no match)
+	// 3: 今日と同じ月日 (match)
+	bot := &mockBot{}
+	today := time_util.LocalTime()
+	yesterday := today.AddDate(0, 0, -1)
+	past := time.Date(today.Year()-5, today.Month(), today.Day(), 0, 0, 0, 0, today.Location())
+
+	am := &AnniversaryManager{
+		Anniversaries: []table.Anniversary{
+			{ID: "1", Date: past.Format("2006-01-02"), Period: "100", Name: "五周年", RoomKey: "roomA"},
+			{ID: "2", Date: yesterday.Format("2006-01-02"), Period: "9999", Name: "昨日", RoomKey: "roomB"},
+			{ID: "3", Date: today.Format("2006-01-02"), Period: "100", Name: "本日", RoomKey: "roomC"},
+		},
+		Bot: bot,
+	}
+
+	if err := am.Run(context.Background()); err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(bot.sent) != 2 {
+		t.Fatalf("マッチ2件のみ送信されるべきだが %d 件だった", len(bot.sent))
+	}
+	if bot.sent[0].roomKey != "roomA" {
+		t.Errorf("1件目の roomKey が不正: %q", bot.sent[0].roomKey)
+	}
+	if bot.sent[1].roomKey != "roomC" {
+		t.Errorf("2件目の roomKey が不正: %q", bot.sent[1].roomKey)
+	}
+}
+
 func TestAnniversaryManager_Run_PropagatesBotError(t *testing.T) {
 	botErr := errors.New("bot failure")
 	bot := &mockBot{err: botErr}

--- a/app/anniversary/anniversary_test.go
+++ b/app/anniversary/anniversary_test.go
@@ -1,0 +1,123 @@
+package anniversary
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/commojun/nyanbot/masterdata/table"
+)
+
+var jst = time.FixedZone("JST", 9*60*60)
+
+func TestMakeCheckMessage(t *testing.T) {
+	t.Run("記念日当日（月日一致・複数年後）: check=true, 年数メッセージ", func(t *testing.T) {
+		a := &table.Anniversary{
+			ID:     "1",
+			Date:   "2020-04-21",
+			Period: "100",
+			Name:   "テスト記念日",
+		}
+		now := time.Date(2026, time.April, 21, 12, 0, 0, 0, jst)
+		msg, check, err := MakeCheckMessage(a, now)
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if !check {
+			t.Errorf("check は true であるべきだが false だった")
+		}
+		expected := fmt.Sprintf(TEMPLATE, a.Name, 6, "年")
+		if msg != expected {
+			t.Errorf("メッセージが不正: got %q, want %q", msg, expected)
+		}
+	})
+
+	t.Run("記念日当日（同年同月同日・0年）: check=true, 0年メッセージ", func(t *testing.T) {
+		a := &table.Anniversary{
+			ID:     "2",
+			Date:   "2026-04-21",
+			Period: "100",
+			Name:   "ゼロ年記念",
+		}
+		now := time.Date(2026, time.April, 21, 0, 0, 0, 0, jst)
+		msg, check, err := MakeCheckMessage(a, now)
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if !check {
+			t.Errorf("check は true であるべきだが false だった")
+		}
+		expected := fmt.Sprintf(TEMPLATE, a.Name, 0, "年")
+		if msg != expected {
+			t.Errorf("メッセージが不正: got %q, want %q", msg, expected)
+		}
+	})
+
+	t.Run("月日不一致・Period倍数一致: check=true, 日数メッセージ", func(t *testing.T) {
+		// 2020-01-01 から 100日後 = 2020-04-10
+		a := &table.Anniversary{
+			ID:     "3",
+			Date:   "2020-01-01",
+			Period: "100",
+			Name:   "百日記念",
+		}
+		now := time.Date(2020, time.April, 10, 0, 0, 0, 0, jst)
+		msg, check, err := MakeCheckMessage(a, now)
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if !check {
+			t.Errorf("check は true であるべきだが false だった")
+		}
+		expected := fmt.Sprintf(TEMPLATE, a.Name, 100, "日")
+		if msg != expected {
+			t.Errorf("メッセージが不正: got %q, want %q", msg, expected)
+		}
+	})
+
+	t.Run("月日不一致・Period倍数不一致: check=false", func(t *testing.T) {
+		a := &table.Anniversary{
+			ID:     "4",
+			Date:   "2020-01-01",
+			Period: "100",
+			Name:   "任意記念日",
+		}
+		// 14日後: 14 % 100 = 14 ≠ 0
+		now := time.Date(2020, time.January, 15, 0, 0, 0, 0, jst)
+		_, check, err := MakeCheckMessage(a, now)
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if check {
+			t.Errorf("check は false であるべきだが true だった")
+		}
+	})
+
+	t.Run("異常系: 不正な日付フォーマット", func(t *testing.T) {
+		a := &table.Anniversary{
+			ID:     "5",
+			Date:   "invalid-date",
+			Period: "100",
+			Name:   "エラーケース",
+		}
+		now := time.Date(2026, time.April, 21, 0, 0, 0, 0, jst)
+		_, _, err := MakeCheckMessage(a, now)
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+
+	t.Run("異常系: 不正なPeriod値", func(t *testing.T) {
+		a := &table.Anniversary{
+			ID:     "6",
+			Date:   "2020-01-01",
+			Period: "not-a-number",
+			Name:   "エラーケース2",
+		}
+		now := time.Date(2026, time.April, 21, 0, 0, 0, 0, jst)
+		_, _, err := MakeCheckMessage(a, now)
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+}

--- a/app/fortune/fortune.go
+++ b/app/fortune/fortune.go
@@ -1,7 +1,6 @@
 package fortune
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 )
@@ -42,9 +41,8 @@ func (f *Fortune) Draw(seed int) string {
 	//日付と引数に依存したseedを作成
 	t := time.Now()
 	day := t.Truncate(time.Hour).Add(-time.Duration(t.Hour()) * time.Hour)
-	fmt.Println(day)
-	rand.Seed(day.Unix() + int64(seed))
-	i := rand.Intn(len(f.Results))
+	r := rand.New(rand.NewSource(day.Unix() + int64(seed)))
+	i := r.Intn(len(f.Results))
 
 	return f.Results[i]
 }

--- a/app/fortune/fortune_test.go
+++ b/app/fortune/fortune_test.go
@@ -1,0 +1,54 @@
+package fortune
+
+import (
+	"testing"
+)
+
+func TestDrawByStringSeed(t *testing.T) {
+	f := New()
+
+	t.Run("同一seed文字列は同一結果を返す（冪等性）", func(t *testing.T) {
+		r1 := f.DrawByStringSeed("にゃんこ")
+		r2 := f.DrawByStringSeed("にゃんこ")
+		if r1 != r2 {
+			t.Errorf("同一seedで異なる結果: %q != %q", r1, r2)
+		}
+	})
+
+	t.Run("異なるseed文字列でも有効な運勢が返る", func(t *testing.T) {
+		seeds := []string{"alice", "bob", "charlie"}
+		for _, seed := range seeds {
+			got := f.DrawByStringSeed(seed)
+			if !isValidResult(got) {
+				t.Errorf("seed %q の結果が無効: %q", seed, got)
+			}
+		}
+	})
+
+	t.Run("空文字列でもパニックせず有効な運勢が返る", func(t *testing.T) {
+		got := f.DrawByStringSeed("")
+		if !isValidResult(got) {
+			t.Errorf("空文字列の結果が無効: %q", got)
+		}
+	})
+
+	t.Run("同一実行内で複数のseed文字列がすべて有効な運勢を返す", func(t *testing.T) {
+		seeds := []string{"大吉希望", "test123", "日本語seed", "!@#$"}
+		for _, seed := range seeds {
+			got := f.DrawByStringSeed(seed)
+			if !isValidResult(got) {
+				t.Errorf("seed %q の結果が無効: %q", seed, got)
+			}
+		}
+	})
+}
+
+// isValidResult は結果が有効な運勢（results スライスに含まれる）かどうかを確認する
+func isValidResult(s string) bool {
+	for _, r := range results {
+		if s == r {
+			return true
+		}
+	}
+	return false
+}

--- a/app/linebot/linebot.go
+++ b/app/linebot/linebot.go
@@ -2,10 +2,12 @@ package linebot
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/commojun/nyanbot/config"
 	"github.com/commojun/nyanbot/masterdata"
 	"github.com/line/line-bot-sdk-go/v8/linebot/messaging_api"
+	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
 )
 
 type LineBot struct {
@@ -53,4 +55,8 @@ func (bot *LineBot) TextReply(ctx context.Context, msg string, replyToken string
 		Messages:   []messaging_api.MessageInterface{messaging_api.TextMessage{Text: msg}},
 	})
 	return err
+}
+
+func (bot *LineBot) ParseWebhookRequest(req *http.Request) (*webhook.CallbackRequest, error) {
+	return webhook.ParseRequest(bot.ChannelSecret, req)
 }

--- a/app/linebot/text_message_action/anniversary.go
+++ b/app/linebot/text_message_action/anniversary.go
@@ -1,6 +1,10 @@
 package text_message_action
 
-import "github.com/commojun/nyanbot/app/anniversary"
+import (
+	"context"
+
+	"github.com/commojun/nyanbot/app/anniversary"
+)
 
 var (
 	randomAnniversary = Action{
@@ -9,18 +13,11 @@ var (
 	}
 )
 
-func doRandomAnniversary(tma *TextMessageAction) error {
-	am := anniversary.New(tma.Bot)
-
-	msg, err := am.RandomMsg()
+func doRandomAnniversary(ctx context.Context, tma *TextMessageAction) error {
+	msg, err := anniversary.RandomMsg()
 	if err != nil {
 		return err
 	}
 
-	err = tma.Bot.TextReply(tma.Ctx, msg, tma.Event.ReplyToken)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return tma.Bot.TextReply(ctx, msg, tma.Event.ReplyToken)
 }

--- a/app/linebot/text_message_action/fortune.go
+++ b/app/linebot/text_message_action/fortune.go
@@ -1,6 +1,7 @@
 package text_message_action
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/commojun/nyanbot/app/fortune"
@@ -14,10 +15,9 @@ var (
 	}
 )
 
-func doDrawFortune(tma *TextMessageAction) error {
+func doDrawFortune(ctx context.Context, tma *TextMessageAction) error {
 	userID := extractUserID(tma.Event.Source)
 
-	// 名前取得
 	nickname, err := masterdata.GetKeyVals().Nickname(userID)
 	if err != nil {
 		nickname = "あなた"
@@ -28,5 +28,5 @@ func doDrawFortune(tma *TextMessageAction) error {
 
 	msg := fmt.Sprintf("%sの今日の運勢\n>>>%s<<<", nickname, result)
 
-	return tma.Bot.TextReply(tma.Ctx, msg, tma.Event.ReplyToken)
+	return tma.Bot.TextReply(ctx, msg, tma.Event.ReplyToken)
 }

--- a/app/linebot/text_message_action/ojiline.go
+++ b/app/linebot/text_message_action/ojiline.go
@@ -1,6 +1,7 @@
 package text_message_action
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
@@ -15,10 +16,9 @@ var (
 	}
 )
 
-func doOjisan(tma *TextMessageAction) error {
+func doOjisan(ctx context.Context, tma *TextMessageAction) error {
 	userID := extractUserID(tma.Event.Source)
 
-	// 名前取得
 	nickname, err := masterdata.GetKeyVals().Nickname(userID)
 	if err != nil {
 		nickname = "にゃんこ"
@@ -34,5 +34,5 @@ func doOjisan(tma *TextMessageAction) error {
 		return err
 	}
 
-	return tma.Bot.TextReply(tma.Ctx, msg, tma.Event.ReplyToken)
+	return tma.Bot.TextReply(ctx, msg, tma.Event.ReplyToken)
 }

--- a/app/linebot/text_message_action/tell_id.go
+++ b/app/linebot/text_message_action/tell_id.go
@@ -1,6 +1,7 @@
 package text_message_action
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
@@ -13,7 +14,7 @@ var (
 	}
 )
 
-func doTellID(tma *TextMessageAction) error {
+func doTellID(ctx context.Context, tma *TextMessageAction) error {
 	replyText := ""
 	switch src := tma.Event.Source.(type) {
 	case webhook.UserSource:
@@ -23,5 +24,5 @@ func doTellID(tma *TextMessageAction) error {
 		replyText += fmt.Sprintf("このグループのID: %s\n", src.GroupId)
 	}
 	replyText += "だよ！"
-	return tma.Bot.TextReply(tma.Ctx, replyText, tma.Event.ReplyToken)
+	return tma.Bot.TextReply(ctx, replyText, tma.Event.ReplyToken)
 }

--- a/app/linebot/text_message_action/testdayo.go
+++ b/app/linebot/text_message_action/testdayo.go
@@ -1,5 +1,7 @@
 package text_message_action
 
+import "context"
+
 var (
 	testdayo = Action{
 		Prefix: "てすと",
@@ -7,10 +9,6 @@ var (
 	}
 )
 
-func doTest(tma *TextMessageAction) error {
-	err := tma.Bot.TextReply(tma.Ctx, "これはテストへの返信だよ！！", tma.Event.ReplyToken)
-	if err != nil {
-		return err
-	}
-	return nil
+func doTest(ctx context.Context, tma *TextMessageAction) error {
+	return tma.Bot.TextReply(ctx, "これはテストへの返信だよ！！", tma.Event.ReplyToken)
 }

--- a/app/linebot/text_message_action/text_message_action.go
+++ b/app/linebot/text_message_action/text_message_action.go
@@ -5,20 +5,21 @@ import (
 	"log"
 	"strings"
 
-	"github.com/commojun/nyanbot/app/linebot"
 	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
 )
 
+type LineBot interface {
+	TextReply(ctx context.Context, msg string, replyToken string) error
+}
+
 type TextMessageAction struct {
-	Ctx     context.Context
-	Bot     *linebot.LineBot
+	Bot     LineBot
 	Event   webhook.MessageEvent
 	Message webhook.TextMessageContent
 }
 
-func New(ctx context.Context, bot *linebot.LineBot, event webhook.MessageEvent, msg webhook.TextMessageContent) *TextMessageAction {
+func New(bot LineBot, event webhook.MessageEvent, msg webhook.TextMessageContent) *TextMessageAction {
 	return &TextMessageAction{
-		Ctx:     ctx,
 		Bot:     bot,
 		Event:   event,
 		Message: msg,
@@ -27,7 +28,7 @@ func New(ctx context.Context, bot *linebot.LineBot, event webhook.MessageEvent, 
 
 type Action struct {
 	Prefix string
-	Do     func(*TextMessageAction) error
+	Do     func(context.Context, *TextMessageAction) error
 }
 
 func actions() []Action {
@@ -40,12 +41,12 @@ func actions() []Action {
 	}
 }
 
-func (tma *TextMessageAction) Do() {
+func (tma *TextMessageAction) Do(ctx context.Context) {
 	actFlg := false
 	var err error
 	for _, action := range actions() {
 		if strings.HasPrefix(tma.Message.Text, action.Prefix) {
-			err = action.Do(tma)
+			err = action.Do(ctx, tma)
 			actFlg = true
 			if err != nil {
 				log.Printf("[text_message_action.Do] actionPrefix: %s, error: %s", action.Prefix, err)
@@ -55,23 +56,17 @@ func (tma *TextMessageAction) Do() {
 		}
 	}
 	if !actFlg {
-		err = echo(tma)
+		err = echo(ctx, tma)
 		if err != nil {
 			log.Printf("[text_message_action.Do] action: echo, error: %s, ", err)
 		} else {
 			log.Printf("[text_message_action.Do] action: echo")
 		}
 	}
-
-	return
 }
 
-func echo(tma *TextMessageAction) error {
-	err := tma.Bot.TextReply(tma.Ctx, tma.Message.Text, tma.Event.ReplyToken)
-	if err != nil {
-		return err
-	}
-	return nil
+func echo(ctx context.Context, tma *TextMessageAction) error {
+	return tma.Bot.TextReply(ctx, tma.Message.Text, tma.Event.ReplyToken)
 }
 
 func extractUserID(src webhook.SourceInterface) string {

--- a/app/linebot/text_message_action/text_message_action.go
+++ b/app/linebot/text_message_action/text_message_action.go
@@ -42,26 +42,24 @@ func actions() []Action {
 }
 
 func (tma *TextMessageAction) Do(ctx context.Context) {
-	actFlg := false
-	var err error
+	// 先勝ち: 最初にマッチしたactionのみ実行する (LINE の ReplyToken が1回限りのため)
 	for _, action := range actions() {
 		if strings.HasPrefix(tma.Message.Text, action.Prefix) {
-			err = action.Do(ctx, tma)
-			actFlg = true
+			err := action.Do(ctx, tma)
 			if err != nil {
 				log.Printf("[text_message_action.Do] actionPrefix: %s, error: %s", action.Prefix, err)
 			} else {
 				log.Printf("[text_message_action.Do] actionPrefix: %s", action.Prefix)
 			}
+			return
 		}
 	}
-	if !actFlg {
-		err = echo(ctx, tma)
-		if err != nil {
-			log.Printf("[text_message_action.Do] action: echo, error: %s, ", err)
-		} else {
-			log.Printf("[text_message_action.Do] action: echo")
-		}
+	// どのactionにもマッチしなかった場合のみechoにフォールバック
+	err := echo(ctx, tma)
+	if err != nil {
+		log.Printf("[text_message_action.Do] action: echo, error: %s, ", err)
+	} else {
+		log.Printf("[text_message_action.Do] action: echo")
 	}
 }
 

--- a/app/linebot/text_message_action/text_message_action_test.go
+++ b/app/linebot/text_message_action/text_message_action_test.go
@@ -1,0 +1,116 @@
+package text_message_action
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
+)
+
+type mockBot struct {
+	replies []replyCall
+	err     error
+}
+
+type replyCall struct {
+	msg        string
+	replyToken string
+}
+
+func (m *mockBot) TextReply(ctx context.Context, msg string, replyToken string) error {
+	m.replies = append(m.replies, replyCall{msg: msg, replyToken: replyToken})
+	return m.err
+}
+
+func newEventWithText(text string) (webhook.MessageEvent, webhook.TextMessageContent) {
+	event := webhook.MessageEvent{
+		ReplyToken: "reply-token-xyz",
+		Source:     webhook.UserSource{UserId: "U-test"},
+	}
+	msg := webhook.TextMessageContent{
+		Id:   "msg-1",
+		Text: text,
+	}
+	return event, msg
+}
+
+func TestTextMessageAction_Do_EchoFallback(t *testing.T) {
+	bot := &mockBot{}
+	event, msg := newEventWithText("プレフィックスにマッチしないテキスト")
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Fatalf("返信回数は 1 であるべきだが %d だった", len(bot.replies))
+	}
+	got := bot.replies[0]
+	if got.msg != "プレフィックスにマッチしないテキスト" {
+		t.Errorf("echo メッセージが不正: got %q", got.msg)
+	}
+	if got.replyToken != "reply-token-xyz" {
+		t.Errorf("replyToken が不正: got %q", got.replyToken)
+	}
+}
+
+func TestTextMessageAction_Do_TestdayoPrefix(t *testing.T) {
+	bot := &mockBot{}
+	event, msg := newEventWithText("てすと")
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Fatalf("返信回数は 1 であるべきだが %d だった", len(bot.replies))
+	}
+	if bot.replies[0].msg != "これはテストへの返信だよ！！" {
+		t.Errorf("testdayo の返信が不正: got %q", bot.replies[0].msg)
+	}
+}
+
+func TestTextMessageAction_Do_TellIDPrefix(t *testing.T) {
+	bot := &mockBot{}
+	event, msg := newEventWithText("ID")
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Fatalf("返信回数は 1 であるべきだが %d だった", len(bot.replies))
+	}
+	got := bot.replies[0].msg
+	if !strings.Contains(got, "U-test") {
+		t.Errorf("UserID が含まれるべきだが含まれなかった: %q", got)
+	}
+}
+
+func TestTextMessageAction_Do_NoMatchNotDoubled(t *testing.T) {
+	// echo fallback 時に通常 action が走らないことを確認
+	bot := &mockBot{}
+	event, msg := newEventWithText("hoge")
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Errorf("echo のみで 1 回だけ返信するべきだが %d 回だった", len(bot.replies))
+	}
+}
+
+func TestTextMessageAction_Do_BotErrorDoesNotPanic(t *testing.T) {
+	// Bot がエラーを返しても Do は panic せずログ出力して抜ける
+	bot := &mockBot{err: &botError{}}
+	event, msg := newEventWithText("てすと")
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Errorf("エラーでも送信試行は行われるべき")
+	}
+}
+
+type botError struct{}
+
+func (e *botError) Error() string { return "bot failure" }

--- a/app/linebot/text_message_action/text_message_action_test.go
+++ b/app/linebot/text_message_action/text_message_action_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/commojun/nyanbot/masterdata"
+	"github.com/commojun/nyanbot/masterdata/key_value"
+	"github.com/commojun/nyanbot/masterdata/table"
 	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
 )
 
@@ -69,7 +72,7 @@ func TestTextMessageAction_Do_TestdayoPrefix(t *testing.T) {
 	}
 }
 
-func TestTextMessageAction_Do_TellIDPrefix(t *testing.T) {
+func TestTextMessageAction_Do_TellIDPrefix_UserSource(t *testing.T) {
 	bot := &mockBot{}
 	event, msg := newEventWithText("ID")
 	tma := New(bot, event, msg)
@@ -83,18 +86,170 @@ func TestTextMessageAction_Do_TellIDPrefix(t *testing.T) {
 	if !strings.Contains(got, "U-test") {
 		t.Errorf("UserID が含まれるべきだが含まれなかった: %q", got)
 	}
+	if strings.Contains(got, "このグループのID") {
+		t.Errorf("UserSource では Group ID の記述は含まれないべき: %q", got)
+	}
 }
 
-func TestTextMessageAction_Do_NoMatchNotDoubled(t *testing.T) {
-	// echo fallback 時に通常 action が走らないことを確認
+func TestTextMessageAction_Do_TellIDPrefix_GroupSource(t *testing.T) {
 	bot := &mockBot{}
-	event, msg := newEventWithText("hoge")
+	event := webhook.MessageEvent{
+		ReplyToken: "reply-token-grp",
+		Source: webhook.GroupSource{
+			UserId:  "U-grouser",
+			GroupId: "G-12345",
+		},
+	}
+	msg := webhook.TextMessageContent{Id: "msg-grp", Text: "ID"}
 	tma := New(bot, event, msg)
 
 	tma.Do(context.Background())
 
 	if len(bot.replies) != 1 {
-		t.Errorf("echo のみで 1 回だけ返信するべきだが %d 回だった", len(bot.replies))
+		t.Fatalf("返信回数は 1 であるべきだが %d だった", len(bot.replies))
+	}
+	got := bot.replies[0].msg
+	if !strings.Contains(got, "U-grouser") {
+		t.Errorf("UserID が含まれるべき: %q", got)
+	}
+	if !strings.Contains(got, "G-12345") {
+		t.Errorf("GroupID が含まれるべき: %q", got)
+	}
+}
+
+func TestTextMessageAction_Do_OnlyFirstMatchFires(t *testing.T) {
+	// 先勝ち仕様: 複数 action がマッチ可能でも最初の1つだけ fire する
+	// 現行 prefix は重複していないが、echo が後続で走らないことを確認する
+	// （echo が走ると返信2回になり ReplyToken 失効エラーが起きる）
+	bot := &mockBot{}
+	event, msg := newEventWithText("てすと") // testdayo にマッチ
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Errorf("先勝ち仕様で返信は1回のみであるべきだが %d 回だった", len(bot.replies))
+	}
+	// testdayoのメッセージ内容が返る（echo のテキストコピーではない）
+	if bot.replies[0].msg != "これはテストへの返信だよ！！" {
+		t.Errorf("testdayo が実行されるべきだが echo が実行された: %q", bot.replies[0].msg)
+	}
+}
+
+// --- masterdata 依存の action テスト ---
+
+func setupMasterData() func() {
+	original := getMasterDataSnapshot()
+	md := &masterdata.MasterData{
+		Tables: &table.Tables{
+			Anniversaries: []table.Anniversary{
+				{
+					ID:      "a1",
+					Date:    "2020-01-01",
+					Period:  "1",
+					Name:    "テスト記念日",
+					RoomKey: "test-room",
+				},
+			},
+		},
+		KeyVals: &key_value.KVs{
+			Nicknames: map[string]string{
+				"U-test": "にゃんこもじゅん",
+			},
+		},
+	}
+	masterdata.SetTestData(md)
+	return func() { masterdata.SetTestData(original) }
+}
+
+func getMasterDataSnapshot() *masterdata.MasterData {
+	return &masterdata.MasterData{
+		Tables:  masterdata.GetTables(),
+		KeyVals: masterdata.GetKeyVals(),
+	}
+}
+
+func TestTextMessageAction_Do_FortunePrefix(t *testing.T) {
+	restore := setupMasterData()
+	defer restore()
+
+	bot := &mockBot{}
+	event, msg := newEventWithText("おみくじ")
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Fatalf("返信回数は 1 であるべきだが %d だった", len(bot.replies))
+	}
+	got := bot.replies[0].msg
+	if !strings.Contains(got, "にゃんこもじゅん") {
+		t.Errorf("ニックネームが含まれるべき: %q", got)
+	}
+	if !strings.Contains(got, "今日の運勢") {
+		t.Errorf("運勢フォーマットが含まれるべき: %q", got)
+	}
+}
+
+func TestTextMessageAction_Do_FortunePrefix_UnknownUser(t *testing.T) {
+	restore := setupMasterData()
+	defer restore()
+
+	bot := &mockBot{}
+	event := webhook.MessageEvent{
+		ReplyToken: "reply-token-unknown",
+		Source:     webhook.UserSource{UserId: "U-unknown"},
+	}
+	msg := webhook.TextMessageContent{Id: "msg-u", Text: "おみくじ"}
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Fatalf("返信回数は 1 であるべきだが %d だった", len(bot.replies))
+	}
+	got := bot.replies[0].msg
+	// 未知ユーザーは "あなた" にフォールバック
+	if !strings.Contains(got, "あなた") {
+		t.Errorf("未知ユーザーは 'あなた' フォールバックするべき: %q", got)
+	}
+}
+
+func TestTextMessageAction_Do_OjisanPrefix(t *testing.T) {
+	restore := setupMasterData()
+	defer restore()
+
+	bot := &mockBot{}
+	event, msg := newEventWithText("おじさん")
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Fatalf("返信回数は 1 であるべきだが %d だった", len(bot.replies))
+	}
+	// ojisan の生成物は乱数依存なので内容詳細は検証しない。空文字でないことのみ確認
+	if bot.replies[0].msg == "" {
+		t.Errorf("おじさんメッセージは空であってはならない")
+	}
+}
+
+func TestTextMessageAction_Do_AnniversaryPrefix(t *testing.T) {
+	restore := setupMasterData()
+	defer restore()
+
+	bot := &mockBot{}
+	event, msg := newEventWithText("今日は何の日")
+	tma := New(bot, event, msg)
+
+	tma.Do(context.Background())
+
+	if len(bot.replies) != 1 {
+		t.Fatalf("返信回数は 1 であるべきだが %d だった", len(bot.replies))
+	}
+	got := bot.replies[0].msg
+	if !strings.Contains(got, "テスト記念日") {
+		t.Errorf("記念日名が含まれるべき: %q", got)
 	}
 }
 

--- a/app/sheet/sheet.go
+++ b/app/sheet/sheet.go
@@ -5,7 +5,8 @@ import (
 
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
-	"google.golang.org/api/sheets/v4"
+	"google.golang.org/api/option"
+	sheets "google.golang.org/api/sheets/v4"
 )
 
 type Config struct {
@@ -31,7 +32,7 @@ func New(ctx context.Context, cfg Config) (*Sheet, error) {
 		jwtCfg.TokenURL = google.JWTTokenURL
 	}
 
-	sheetService, err := sheets.New(jwtCfg.Client(ctx))
+	sheetService, err := sheets.NewService(ctx, option.WithHTTPClient(jwtCfg.Client(ctx)))
 	if err != nil {
 		return &Sheet{}, err
 	}
@@ -41,11 +42,10 @@ func New(ctx context.Context, cfg Config) (*Sheet, error) {
 	}, nil
 }
 
-func (sheet *Sheet) Get(ctx context.Context, spreadsheetID string, sheetName string) (*sheets.ValueRange, error) {
+func (sheet *Sheet) Get(ctx context.Context, spreadsheetID string, sheetName string) ([][]any, error) {
 	res, err := sheet.Service.Spreadsheets.Values.Get(spreadsheetID, sheetName).Context(ctx).Do()
 	if err != nil {
-		return &sheets.ValueRange{}, err
+		return nil, err
 	}
-
-	return res, err
+	return res.Values, nil
 }

--- a/app/time_util/time_util.go
+++ b/app/time_util/time_util.go
@@ -1,7 +1,6 @@
 package time_util
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -22,7 +21,6 @@ func JSTParse(s string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	fmt.Println(t)
 	return t, nil
 }
 

--- a/app/time_util/time_util_test.go
+++ b/app/time_util/time_util_test.go
@@ -1,0 +1,67 @@
+package time_util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestJSTParse(t *testing.T) {
+	t.Run("正常系: 正しいフォーマットの文字列をパース", func(t *testing.T) {
+		s := "2026-04-21 09:00:00"
+		got, err := JSTParse(s)
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		// タイムゾーンがJST(+09:00)であること
+		_, offset := got.Zone()
+		if offset != 9*60*60 {
+			t.Errorf("タイムゾーンオフセットが不正: got %d, want %d", offset, 9*60*60)
+		}
+		name, _ := got.Zone()
+		if name != "JST" {
+			t.Errorf("タイムゾーン名が不正: got %s, want JST", name)
+		}
+		// 年月日時分秒が正しくパースされていること
+		if got.Year() != 2026 || got.Month() != time.April || got.Day() != 21 {
+			t.Errorf("日付が不正: got %v", got)
+		}
+		if got.Hour() != 9 || got.Minute() != 0 || got.Second() != 0 {
+			t.Errorf("時刻が不正: got %v", got)
+		}
+	})
+
+	t.Run("正常系: 別の日時をパース", func(t *testing.T) {
+		s := "2018-07-12 07:30:00"
+		got, err := JSTParse(s)
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if got.Year() != 2018 || got.Month() != time.July || got.Day() != 12 {
+			t.Errorf("日付が不正: got %v", got)
+		}
+		if got.Hour() != 7 || got.Minute() != 30 || got.Second() != 0 {
+			t.Errorf("時刻が不正: got %v", got)
+		}
+	})
+
+	t.Run("異常系: 不正なフォーマット", func(t *testing.T) {
+		_, err := JSTParse("not-a-date")
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+
+	t.Run("異常系: 空文字列", func(t *testing.T) {
+		_, err := JSTParse("")
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+
+	t.Run("異常系: 日付部分のみ（時刻なし）", func(t *testing.T) {
+		_, err := JSTParse("2026-04-21")
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+}

--- a/masterdata/key_value/key_value.go
+++ b/masterdata/key_value/key_value.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-
-	"github.com/commojun/nyanbot/app/sheet"
 )
 
 var (
@@ -20,50 +18,85 @@ type KVs struct {
 	Tests     map[string]string `kvName:"testkv"`
 }
 
-func LoadKVsFromSheet(ctx context.Context, s *sheet.Sheet, sheetID string) (*KVs, error) {
+// SheetFetcher: スプレッドシートから指定シート名の行データを取得するための抽象
+type SheetFetcher interface {
+	Get(ctx context.Context, spreadsheetID string, sheetName string) ([][]any, error)
+}
+
+func LoadKVsFromSheet(ctx context.Context, s SheetFetcher, sheetID string) (*KVs, error) {
 	kvs := &KVs{}
 
 	kvsType := reflect.TypeOf(*kvs)
 	for i := 0; i < kvsType.NumField(); i++ {
-		// kvを作成
 		kvName := kvsType.Field(i).Tag.Get("kvName")
 		kv, err := getKVFromSheet(ctx, s, kvName, sheetID)
 		if err != nil {
 			return nil, err
 		}
-		// 生成したkvをkvsにセットする
 		reflect.ValueOf(kvs).Elem().Field(i).Set(reflect.ValueOf(*kv))
 	}
 
 	return kvs, nil
 }
 
-func getKVFromSheet(ctx context.Context, s *sheet.Sheet, kvName string, sheetID string) (*map[string]string, error) {
-	// シートからデータを取得
-	res, err := s.Get(ctx, sheetID, kvName)
+func getKVFromSheet(ctx context.Context, s SheetFetcher, kvName string, sheetID string) (*map[string]string, error) {
+	rows, err := s.Get(ctx, sheetID, kvName)
 	if err != nil {
 		return &map[string]string{}, err
 	}
+	kv, err := parseKVRows(rows)
+	if err != nil {
+		return &map[string]string{}, err
+	}
+	return &kv, nil
+}
 
-	// シートのヘッダ情報
-	header := res.Values[0]
+// parseKVRows: Google Sheets の生データ ([][]any) を map[string]string にパースする純粋関数
+// 1行目をヘッダとして "key" と "value" 列の位置を検出し、以降の行を取り込む。key が空の行はスキップ
+func parseKVRows(rows [][]any) (map[string]string, error) {
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("no rows: header missing")
+	}
+
+	header := rows[0]
 	headerMap := make(map[string]int, len(header))
 	for i, cell := range header {
-		headerMap[cell.(string)] = i
+		name, ok := cell.(string)
+		if !ok {
+			return nil, fmt.Errorf("header cell %d is not a string", i)
+		}
+		headerMap[name] = i
 	}
 
-	data := res.Values[1:]
+	keyIdx, ok := headerMap["key"]
+	if !ok {
+		return nil, fmt.Errorf("key column is missing in header")
+	}
+	valueIdx, ok := headerMap["value"]
+	if !ok {
+		return nil, fmt.Errorf("value column is missing in header")
+	}
+
 	kv := map[string]string{}
-	for _, row := range data {
-		// keyが空の行はスキップする
-		if row[headerMap["key"]] == "" {
+	for rowIdx, row := range rows[1:] {
+		if keyIdx >= len(row) || row[keyIdx] == "" {
 			continue
 		}
-
-		kv[row[headerMap["key"]].(string)] = row[headerMap["value"]].(string)
+		key, ok := row[keyIdx].(string)
+		if !ok {
+			return nil, fmt.Errorf("row %d key is not a string", rowIdx+1)
+		}
+		var value string
+		if valueIdx < len(row) {
+			v, ok := row[valueIdx].(string)
+			if !ok {
+				return nil, fmt.Errorf("row %d value is not a string", rowIdx+1)
+			}
+			value = v
+		}
+		kv[key] = value
 	}
-
-	return &kv, err
+	return kv, nil
 }
 
 // RoomID: ルームキーからルームIDを取得

--- a/masterdata/key_value/key_value_test.go
+++ b/masterdata/key_value/key_value_test.go
@@ -1,6 +1,8 @@
 package key_value
 
 import (
+	"context"
+	"errors"
 	"testing"
 )
 
@@ -88,4 +90,182 @@ func TestNickname(t *testing.T) {
 			t.Error("エラーが返るべきだが nil だった")
 		}
 	})
+}
+
+// --- parseKVRows テスト ---
+
+func TestParseKVRows_Normal(t *testing.T) {
+	rows := [][]any{
+		{"key", "value"},
+		{"main", "room_id_001"},
+		{"sub", "room_id_002"},
+	}
+	kv, err := parseKVRows(rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(kv) != 2 {
+		t.Fatalf("len=%d, want 2", len(kv))
+	}
+	if kv["main"] != "room_id_001" || kv["sub"] != "room_id_002" {
+		t.Errorf("値が不正: %+v", kv)
+	}
+}
+
+func TestParseKVRows_SkipsEmptyKey(t *testing.T) {
+	rows := [][]any{
+		{"key", "value"},
+		{"foo", "1"},
+		{"", "orphan"}, // 空キー行
+		{"bar", "2"},
+	}
+	kv, err := parseKVRows(rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(kv) != 2 {
+		t.Fatalf("空キーはスキップされるべきで len=2 だが %d だった", len(kv))
+	}
+	if kv["foo"] != "1" || kv["bar"] != "2" {
+		t.Errorf("スキップ後の内容が不正: %+v", kv)
+	}
+}
+
+func TestParseKVRows_ShuffledColumnOrder(t *testing.T) {
+	rows := [][]any{
+		{"value", "key"}, // 列順逆
+		{"VAL1", "K1"},
+	}
+	kv, err := parseKVRows(rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if kv["K1"] != "VAL1" {
+		t.Errorf("列順入替でマッピング失敗: %+v", kv)
+	}
+}
+
+func TestParseKVRows_HeaderOnly_EmptyMap(t *testing.T) {
+	rows := [][]any{
+		{"key", "value"},
+	}
+	kv, err := parseKVRows(rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(kv) != 0 {
+		t.Errorf("空マップであるべきだが len=%d", len(kv))
+	}
+}
+
+func TestParseKVRows_EmptyRows_Error(t *testing.T) {
+	_, err := parseKVRows([][]any{})
+	if err == nil {
+		t.Error("空入力でエラーが返るべきだが nil だった")
+	}
+}
+
+func TestParseKVRows_MissingKeyColumn_Error(t *testing.T) {
+	rows := [][]any{
+		{"value"}, // key 欠落
+		{"val1"},
+	}
+	_, err := parseKVRows(rows)
+	if err == nil {
+		t.Error("key列欠落でエラーが返るべきだが nil だった")
+	}
+}
+
+func TestParseKVRows_MissingValueColumn_Error(t *testing.T) {
+	rows := [][]any{
+		{"key"}, // value 欠落
+		{"k1"},
+	}
+	_, err := parseKVRows(rows)
+	if err == nil {
+		t.Error("value列欠落でエラーが返るべきだが nil だった")
+	}
+}
+
+// --- LoadKVsFromSheet テスト（SheetFetcher mock） ---
+
+type mockFetcher struct {
+	data map[string][][]any
+	err  error
+}
+
+func (m *mockFetcher) Get(ctx context.Context, sheetID string, sheetName string) ([][]any, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	rows, ok := m.data[sheetName]
+	if !ok {
+		return nil, errors.New("sheet not found: " + sheetName)
+	}
+	return rows, nil
+}
+
+func TestLoadKVsFromSheet_Success(t *testing.T) {
+	fetcher := &mockFetcher{
+		data: map[string][][]any{
+			"room": {
+				{"key", "value"},
+				{"main", "R-001"},
+				{"sub", "R-002"},
+			},
+			"nickname": {
+				{"key", "value"},
+				{"user_a", "にゃんこ"},
+			},
+			"testkv": {
+				{"key", "value"},
+				{"foo", "bar"},
+			},
+		},
+	}
+
+	kvs, err := LoadKVsFromSheet(context.Background(), fetcher, "dummy-sheet-id")
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(kvs.Rooms) != 2 {
+		t.Errorf("Rooms len=%d, want 2", len(kvs.Rooms))
+	}
+	if len(kvs.Nicknames) != 1 {
+		t.Errorf("Nicknames len=%d, want 1", len(kvs.Nicknames))
+	}
+	if len(kvs.Tests) != 1 {
+		t.Errorf("Tests len=%d, want 1", len(kvs.Tests))
+	}
+	if kvs.Rooms["main"] != "R-001" {
+		t.Errorf("Rooms['main'] = %q, want %q", kvs.Rooms["main"], "R-001")
+	}
+	if kvs.Nicknames["user_a"] != "にゃんこ" {
+		t.Errorf("Nicknames['user_a'] = %q", kvs.Nicknames["user_a"])
+	}
+}
+
+func TestLoadKVsFromSheet_FetcherError(t *testing.T) {
+	fetcher := &mockFetcher{err: errors.New("sheet error")}
+
+	_, err := LoadKVsFromSheet(context.Background(), fetcher, "dummy-sheet-id")
+	if err == nil {
+		t.Error("fetcher エラーが伝播するべきだが nil だった")
+	}
+}
+
+func TestLoadKVsFromSheet_ParseError(t *testing.T) {
+	// room シートが空 → parseKVRows でエラー
+	fetcher := &mockFetcher{
+		data: map[string][][]any{
+			"room":     {},
+			"nickname": {},
+			"testkv":   {},
+		},
+	}
+
+	_, err := LoadKVsFromSheet(context.Background(), fetcher, "dummy-sheet-id")
+	if err == nil {
+		t.Error("パースエラーが伝播するべきだが nil だった")
+	}
 }

--- a/masterdata/key_value/key_value_test.go
+++ b/masterdata/key_value/key_value_test.go
@@ -1,0 +1,91 @@
+package key_value
+
+import (
+	"testing"
+)
+
+func TestRoomID(t *testing.T) {
+	kvs := &KVs{
+		Rooms: map[string]string{
+			"main":  "room_id_001",
+			"sub":   "room_id_002",
+		},
+	}
+
+	t.Run("存在するキーでルームIDを取得", func(t *testing.T) {
+		got, err := kvs.RoomID("main")
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if got != "room_id_001" {
+			t.Errorf("RoomID: got %q, want %q", got, "room_id_001")
+		}
+	})
+
+	t.Run("別の存在するキーでルームIDを取得", func(t *testing.T) {
+		got, err := kvs.RoomID("sub")
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if got != "room_id_002" {
+			t.Errorf("RoomID: got %q, want %q", got, "room_id_002")
+		}
+	})
+
+	t.Run("存在しないキーはエラーを返す", func(t *testing.T) {
+		_, err := kvs.RoomID("not_exist")
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+
+	t.Run("空文字列キーはエラーを返す", func(t *testing.T) {
+		_, err := kvs.RoomID("")
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+}
+
+func TestNickname(t *testing.T) {
+	kvs := &KVs{
+		Nicknames: map[string]string{
+			"user_001": "にゃんこ",
+			"user_002": "たろう",
+		},
+	}
+
+	t.Run("存在するユーザーIDでニックネームを取得", func(t *testing.T) {
+		got, err := kvs.Nickname("user_001")
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if got != "にゃんこ" {
+			t.Errorf("Nickname: got %q, want %q", got, "にゃんこ")
+		}
+	})
+
+	t.Run("別の存在するユーザーIDでニックネームを取得", func(t *testing.T) {
+		got, err := kvs.Nickname("user_002")
+		if err != nil {
+			t.Fatalf("予期しないエラー: %v", err)
+		}
+		if got != "たろう" {
+			t.Errorf("Nickname: got %q, want %q", got, "たろう")
+		}
+	})
+
+	t.Run("存在しないユーザーIDはエラーを返す", func(t *testing.T) {
+		_, err := kvs.Nickname("not_exist")
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+
+	t.Run("空文字列ユーザーIDはエラーを返す", func(t *testing.T) {
+		_, err := kvs.Nickname("")
+		if err == nil {
+			t.Error("エラーが返るべきだが nil だった")
+		}
+	})
+}

--- a/masterdata/table/table.go
+++ b/masterdata/table/table.go
@@ -2,9 +2,8 @@ package table
 
 import (
 	"context"
+	"fmt"
 	"reflect"
-
-	"github.com/commojun/nyanbot/app/sheet"
 )
 
 type Tables struct {
@@ -12,58 +11,85 @@ type Tables struct {
 	Anniversaries []Anniversary `tableName:"anniversary"`
 }
 
-func LoadTablesFromSheet(ctx context.Context, s *sheet.Sheet, sheetID string) (*Tables, error) {
+// SheetFetcher: スプレッドシートから指定シート名の行データを取得するための抽象
+type SheetFetcher interface {
+	Get(ctx context.Context, spreadsheetID string, sheetName string) ([][]any, error)
+}
+
+func LoadTablesFromSheet(ctx context.Context, s SheetFetcher, sheetID string) (*Tables, error) {
 	ts := &Tables{}
 
 	tsType := reflect.TypeOf(*ts)
 	for i := 0; i < tsType.NumField(); i++ {
-		// tableを生成
 		tName := tsType.Field(i).Tag.Get("tableName")
 		tType := tsType.Field(i).Type
 		tValue, err := getTableFromSheet(ctx, s, tType, tName, sheetID)
 		if err != nil {
 			return nil, err
 		}
-		// 生成したtableをtablesにセットする
 		reflect.ValueOf(ts).Elem().Field(i).Set(tValue.Elem())
 	}
 
 	return ts, nil
 }
 
-func getTableFromSheet(ctx context.Context, s *sheet.Sheet, tType reflect.Type, tName string, sheetID string) (reflect.Value, error) {
-	// シートからデータを取得
-	res, err := s.Get(ctx, sheetID, tName)
+func getTableFromSheet(ctx context.Context, s SheetFetcher, tType reflect.Type, tName string, sheetID string) (reflect.Value, error) {
+	rows, err := s.Get(ctx, sheetID, tName)
 	if err != nil {
 		return reflect.Value{}, err
 	}
+	return parseTableRows(tType, rows)
+}
 
-	// テーブルのヘッダ情報
-	header := res.Values[0]
-	headerMap := make(map[string]int, len(header))
-	for i, cell := range header {
-		headerMap[cell.(string)] = i
+// parseTableRows: Google Sheets の生データ ([][]any) を構造体スライスにマッピングする純粋関数
+// tType は対象スライス型 (例: []Alarm, []Anniversary)。構造体フィールドは json タグでヘッダ列と対応づける
+func parseTableRows(tType reflect.Type, rows [][]any) (reflect.Value, error) {
+	if len(rows) == 0 {
+		return reflect.New(tType), fmt.Errorf("no rows: header missing")
 	}
 
-	data := res.Values[1:]
+	header := rows[0]
+	headerMap := make(map[string]int, len(header))
+	for i, cell := range header {
+		name, ok := cell.(string)
+		if !ok {
+			return reflect.Value{}, fmt.Errorf("header cell %d is not a string", i)
+		}
+		headerMap[name] = i
+	}
+
+	idIdx, ok := headerMap["id"]
+	if !ok {
+		return reflect.Value{}, fmt.Errorf("id column is missing in header")
+	}
+
 	tValue := reflect.New(tType)
-	for _, row := range data {
-		// id列が空の行はスキップする
-		if row[headerMap["id"]] == "" {
+	objType := tType.Elem()
+	for rowIdx, row := range rows[1:] {
+		// id列が空の行はスキップ
+		if idIdx >= len(row) || row[idIdx] == "" {
 			continue
 		}
 
-		// 行データの作成
-		objType := tType.Elem()
 		objValue := reflect.New(objType)
 		for j := 0; j < objType.NumField(); j++ {
-			cIndex := headerMap[objType.Field(j).Tag.Get("json")]
-			value := row[cIndex]
-			objValue.Elem().Field(j).SetString(value.(string))
+			colName := objType.Field(j).Tag.Get("json")
+			cIndex, ok := headerMap[colName]
+			if !ok {
+				return reflect.Value{}, fmt.Errorf("column %q (field %q) not found in header", colName, objType.Field(j).Name)
+			}
+			if cIndex >= len(row) {
+				// 行末が足りない場合は空文字扱い
+				continue
+			}
+			value, ok := row[cIndex].(string)
+			if !ok {
+				return reflect.Value{}, fmt.Errorf("row %d column %q is not a string", rowIdx+1, colName)
+			}
+			objValue.Elem().Field(j).SetString(value)
 		}
-		// 行を追加
 		tValue.Elem().Set(reflect.Append(tValue.Elem(), objValue.Elem()))
 	}
 
-	return tValue, err
+	return tValue, nil
 }

--- a/masterdata/table/table_test.go
+++ b/masterdata/table/table_test.go
@@ -1,0 +1,249 @@
+package table
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// --- parseTableRows テスト ---
+
+func TestParseTableRows_Alarm_Normal(t *testing.T) {
+	rows := [][]any{
+		{"id", "minute", "hour", "day_of_month", "month", "day_of_week", "week_num", "message", "room_key"},
+		{"1", "30", "10", "*", "*", "*", "*", "おはよう", "roomA"},
+		{"2", "0", "20", "*", "*", "*", "*", "おやすみ", "roomB"},
+	}
+
+	v, err := parseTableRows(reflect.TypeOf([]Alarm{}), rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	got := v.Elem().Interface().([]Alarm)
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	if got[0].ID != "1" || got[0].Minute != "30" || got[0].Message != "おはよう" || got[0].RoomKey != "roomA" {
+		t.Errorf("1件目が不正: %+v", got[0])
+	}
+	if got[1].ID != "2" || got[1].Hour != "20" || got[1].Message != "おやすみ" {
+		t.Errorf("2件目が不正: %+v", got[1])
+	}
+}
+
+func TestParseTableRows_Anniversary_Normal(t *testing.T) {
+	rows := [][]any{
+		{"id", "date", "period", "name", "room_key"},
+		{"1", "2020-01-01", "100", "記念日A", "roomA"},
+		{"2", "2021-06-15", "365", "記念日B", "roomB"},
+	}
+
+	v, err := parseTableRows(reflect.TypeOf([]Anniversary{}), rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	got := v.Elem().Interface().([]Anniversary)
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	if got[0].Date != "2020-01-01" || got[0].Period != "100" {
+		t.Errorf("1件目が不正: %+v", got[0])
+	}
+}
+
+func TestParseTableRows_SkipsEmptyIDRow(t *testing.T) {
+	rows := [][]any{
+		{"id", "minute", "hour", "day_of_month", "month", "day_of_week", "week_num", "message", "room_key"},
+		{"1", "0", "10", "*", "*", "*", "*", "msg1", "roomA"},
+		{"", "0", "11", "*", "*", "*", "*", "skip", "roomX"}, // 空ID
+		{"3", "0", "12", "*", "*", "*", "*", "msg3", "roomC"},
+	}
+
+	v, err := parseTableRows(reflect.TypeOf([]Alarm{}), rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	got := v.Elem().Interface().([]Alarm)
+	if len(got) != 2 {
+		t.Fatalf("空IDはスキップされるべきで len=2 だが %d だった", len(got))
+	}
+	if got[0].ID != "1" || got[1].ID != "3" {
+		t.Errorf("スキップ後の並びが不正: %+v", got)
+	}
+}
+
+func TestParseTableRows_HeaderOnly_EmptySlice(t *testing.T) {
+	rows := [][]any{
+		{"id", "minute", "hour", "day_of_month", "month", "day_of_week", "week_num", "message", "room_key"},
+	}
+
+	v, err := parseTableRows(reflect.TypeOf([]Alarm{}), rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	got := v.Elem().Interface().([]Alarm)
+	if len(got) != 0 {
+		t.Errorf("データ行なしの場合は空スライスであるべきだが len=%d だった", len(got))
+	}
+}
+
+func TestParseTableRows_ShuffledColumnOrder(t *testing.T) {
+	// 列順が構造体定義と異なっていても、json タグで紐づくので正しくマッピングされる
+	rows := [][]any{
+		{"room_key", "message", "week_num", "day_of_week", "month", "day_of_month", "hour", "minute", "id"},
+		{"roomZ", "逆順テスト", "*", "*", "*", "*", "5", "45", "42"},
+	}
+
+	v, err := parseTableRows(reflect.TypeOf([]Alarm{}), rows)
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	got := v.Elem().Interface().([]Alarm)
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1", len(got))
+	}
+	if got[0].ID != "42" || got[0].Minute != "45" || got[0].Hour != "5" || got[0].RoomKey != "roomZ" || got[0].Message != "逆順テスト" {
+		t.Errorf("列順入替でマッピング失敗: %+v", got[0])
+	}
+}
+
+func TestParseTableRows_EmptyRows_Error(t *testing.T) {
+	_, err := parseTableRows(reflect.TypeOf([]Alarm{}), [][]any{})
+	if err == nil {
+		t.Error("空入力ではエラーが返るべきだが nil だった")
+	}
+}
+
+func TestParseTableRows_MissingIDColumn_Error(t *testing.T) {
+	rows := [][]any{
+		{"minute", "hour", "day_of_month", "month", "day_of_week", "week_num", "message", "room_key"}, // id欠落
+		{"30", "10", "*", "*", "*", "*", "msg", "room"},
+	}
+	_, err := parseTableRows(reflect.TypeOf([]Alarm{}), rows)
+	if err == nil {
+		t.Error("id列欠落でエラーが返るべきだが nil だった")
+	}
+}
+
+func TestParseTableRows_MissingFieldColumn_Error(t *testing.T) {
+	// message 列がヘッダに存在しない → Alarm 構造体の Message フィールドに対応する列がない
+	rows := [][]any{
+		{"id", "minute", "hour", "day_of_month", "month", "day_of_week", "week_num", "room_key"},
+		{"1", "30", "10", "*", "*", "*", "*", "room"},
+	}
+	_, err := parseTableRows(reflect.TypeOf([]Alarm{}), rows)
+	if err == nil {
+		t.Error("構造体フィールドに対応する列欠落でエラーが返るべきだが nil だった")
+	}
+}
+
+func TestParseTableRows_NonStringHeader_Error(t *testing.T) {
+	rows := [][]any{
+		{"id", "minute", 123, "day_of_month", "month", "day_of_week", "week_num", "message", "room_key"},
+		{"1", "30", "10", "*", "*", "*", "*", "msg", "room"},
+	}
+	_, err := parseTableRows(reflect.TypeOf([]Alarm{}), rows)
+	if err == nil {
+		t.Error("非stringヘッダでエラーが返るべきだが nil だった")
+	}
+}
+
+// --- LoadTablesFromSheet テスト（SheetFetcher mock） ---
+
+type mockFetcher struct {
+	data map[string][][]any
+	err  error
+}
+
+func (m *mockFetcher) Get(ctx context.Context, sheetID string, sheetName string) ([][]any, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	rows, ok := m.data[sheetName]
+	if !ok {
+		return nil, errors.New("sheet not found: " + sheetName)
+	}
+	return rows, nil
+}
+
+func TestLoadTablesFromSheet_Success(t *testing.T) {
+	fetcher := &mockFetcher{
+		data: map[string][][]any{
+			"alarm": {
+				{"id", "minute", "hour", "day_of_month", "month", "day_of_week", "week_num", "message", "room_key"},
+				{"1", "30", "10", "*", "*", "*", "*", "alarm1", "roomA"},
+				{"2", "0", "20", "*", "*", "*", "*", "alarm2", "roomB"},
+			},
+			"anniversary": {
+				{"id", "date", "period", "name", "room_key"},
+				{"1", "2020-01-01", "100", "記念日A", "roomX"},
+			},
+		},
+	}
+
+	ts, err := LoadTablesFromSheet(context.Background(), fetcher, "dummy-sheet-id")
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(ts.Alarms) != 2 {
+		t.Errorf("Alarms len=%d, want 2", len(ts.Alarms))
+	}
+	if len(ts.Anniversaries) != 1 {
+		t.Errorf("Anniversaries len=%d, want 1", len(ts.Anniversaries))
+	}
+	if ts.Alarms[0].Message != "alarm1" {
+		t.Errorf("Alarm message不正: %q", ts.Alarms[0].Message)
+	}
+	if ts.Anniversaries[0].Name != "記念日A" {
+		t.Errorf("Anniversary name不正: %q", ts.Anniversaries[0].Name)
+	}
+}
+
+func TestLoadTablesFromSheet_FetcherError(t *testing.T) {
+	fetcher := &mockFetcher{err: errors.New("network down")}
+
+	_, err := LoadTablesFromSheet(context.Background(), fetcher, "dummy-sheet-id")
+	if err == nil {
+		t.Error("fetcher エラーが伝播するべきだが nil だった")
+	}
+}
+
+func TestLoadTablesFromSheet_ParseError(t *testing.T) {
+	// alarm シートだけ壊れたヘッダを返す
+	fetcher := &mockFetcher{
+		data: map[string][][]any{
+			"alarm":       {}, // 空 → parseTableRows でエラー
+			"anniversary": {},
+		},
+	}
+
+	_, err := LoadTablesFromSheet(context.Background(), fetcher, "dummy-sheet-id")
+	if err == nil {
+		t.Error("パースエラーが伝播するべきだが nil だった")
+	}
+}
+
+func TestLoadTablesFromSheet_EmptyButValidSheets(t *testing.T) {
+	fetcher := &mockFetcher{
+		data: map[string][][]any{
+			"alarm": {
+				{"id", "minute", "hour", "day_of_month", "month", "day_of_week", "week_num", "message", "room_key"},
+			},
+			"anniversary": {
+				{"id", "date", "period", "name", "room_key"},
+			},
+		},
+	}
+
+	ts, err := LoadTablesFromSheet(context.Background(), fetcher, "dummy-sheet-id")
+	if err != nil {
+		t.Fatalf("予期しないエラー: %v", err)
+	}
+	if len(ts.Alarms) != 0 {
+		t.Errorf("Alarms は空であるべきだが %d 件", len(ts.Alarms))
+	}
+	if len(ts.Anniversaries) != 0 {
+		t.Errorf("Anniversaries は空であるべきだが %d 件", len(ts.Anniversaries))
+	}
+}


### PR DESCRIPTION
関連Issue: https://github.com/commojun/nyanbot/issues/24

## 概要

nyanbot のテストカバレッジを大幅に拡充した。Phase 1（純粋ロジック関数のテスト）に加え、Phase 2（LineBot interface 化 + Tier 2 テスト）および Phase 3（masterdata の Sheet interface 化 + パース関数抽出）まで実施。**61 テスト全 PASS**。

## Phase 1: 純粋ロジック関数のテスト

実装変更不要な純粋関数に対するユニットテストを追加。

- `app/time_util/time_util_test.go` (新規) — `JSTParse()` 正常系/異常系
- `app/anniversary/anniversary_test.go` (新規) — `MakeCheckMessage()` 各パターン
- `app/fortune/fortune_test.go` (新規) — `DrawByStringSeed()` の冪等性・空文字列
- `masterdata/key_value/key_value_test.go` (新規) — `RoomID()` / `Nickname()`

## Phase 2: LineBot interface 化 + Tier 2 テスト

consumer package ごとに必要なメソッドだけの `LineBot` interface を定義し、モック注入可能にした上でテストを追加。

### リファクタ
- `app/linebot/linebot.go` — `ParseWebhookRequest()` メソッド追加（webhook 署名検証をカプセル化、Y案）
- `app/alarm/alarm.go` / `app/anniversary/anniversary.go` — `LineBot` interface 定義、`Bot` フィールドを interface 型に
- `app/linebot/text_message_action/` — `Ctx` フィールド撤去（Go 慣例違反の解消）、`Do(ctx)` に引数化、`LineBot` interface 定義、各 action を `func(ctx, tma)` シグネチャに
- `api/line_hook.go` — `LineBot` interface 定義、`handleCallback` 抽出、`bot.ParseWebhookRequest` 利用
- `app/anniversary/anniversary.go` — `RandomMsg` を method から package 関数化

### バグ修正
- **TMA.Do の LINE ReplyToken 2重使用問題** — 複数プレフィックスマッチ時に `TextReply` が連続で呼ばれて2回目以降が 400 になる潜在バグを、`return` パターンで先勝ちにして解消

### 追加テスト
- `app/alarm/alarm_test.go` (新規) — `Run()` の空リスト / キャンセル / マッチ / 非マッチ / 混在 / bot エラー継続
- `app/anniversary/anniversary_test.go` (追加) — `Run()` の空 / キャンセル / マッチ / 非マッチ / 混在 / bot エラー伝播 / 不正日付
- `app/linebot/text_message_action/text_message_action_test.go` (新規) — echo fallback / testdayo / tellID (UserSource/GroupSource) / fortune / ojisan / anniversary / 先勝ち / bot エラー
- `api/line_hook_test.go` (新規) — `handleCallback` の成功/署名不正/その他エラー、`actByLineEvents` の各イベント種別 / ctx キャンセル / 複数イベント

## Phase 3: masterdata の Sheet interface 化 + パース関数抽出

reflection を使った複雑なパース処理をテスト可能な形に分離。

### リファクタ
- `app/sheet/sheet.go` — `Get()` の戻り値を `*sheets.ValueRange` → `[][]any` に変更。Google SDK 型への依存を `sheet` パッケージに閉じ込める。併せて deprecated な `sheets.New` を `sheets.NewService` に更新
- `masterdata/table/table.go` — `SheetFetcher` interface 定義、純粋関数 `parseTableRows` を抽出。id列欠落・フィールド対応列欠落・非string値等を明示的にエラー化
- `masterdata/key_value/key_value.go` — 同様に `SheetFetcher` interface + `parseKVRows` 抽出

### 追加テスト
- `masterdata/table/table_test.go` (新規, 13件) — `parseTableRows` 正常系(Alarm/Anniversary) / 空ID行スキップ / ヘッダのみ / 列順入替 / エラー系4種 + `LoadTablesFromSheet` 成功 / fetcher エラー / パースエラー / 空but有効
- `masterdata/key_value/key_value_test.go` (追加, 10件) — `parseKVRows` 同様のケース + `LoadKVsFromSheet` success / fetcher error / parse error

## おまけ

- `.github/workflows/test.yml` — push/PR 時に `go test ./...` を実行する CI を追加
- `interface{}` → `any` への置換（Go 1.18+ 推奨記法）

## 今回スコープ外（将来検討）

- `app/linebot/linebot.go` の LINE SDK ラッパー 4メソッド（モックコスト高）
- `app/server/server.go` の graceful shutdown（integration 寄り）
- `api/message.go` のハンドラテスト（line_hook と同要領で可能）
- `app/ojisan/` のテスト（未確認）
- 将来プレフィックス重複が起きた場合の最長一致対応