### PR TITLE
Issue#12: 天気予報通知機能を追加

### DIFF
--- a/app/linebot/text_message_action/text_message_action.go
+++ b/app/linebot/text_message_action/text_message_action.go
@@ -38,6 +38,7 @@ func actions() []Action {
 		ojiline,
 		drawFortune,
 		randomAnniversary,
+		getWeather,
 	}
 }
 

--- a/app/linebot/text_message_action/weather.go
+++ b/app/linebot/text_message_action/weather.go
@@ -1,0 +1,27 @@
+package text_message_action
+
+import (
+	"context"
+
+	"github.com/commojun/nyanbot/app/weather"
+)
+
+var (
+	getWeather = Action{
+		Prefix: "天気",
+		Do:     doGetWeather,
+	}
+)
+
+func doGetWeather(ctx context.Context, tma *TextMessageAction) error {
+	// 環境変数からcityIDを取得する手段がないため、東京（130010）をデフォルトとする
+	// WeatherCityID は weather_notify 経由でのみ利用可能
+	const defaultCityID = "130010"
+
+	msg, err := weather.Fetch(ctx, defaultCityID)
+	if err != nil {
+		return tma.Bot.TextReply(ctx, "天気の取得に失敗したよ…", tma.Event.ReplyToken)
+	}
+
+	return tma.Bot.TextReply(ctx, msg, tma.Event.ReplyToken)
+}

--- a/app/weather/weather.go
+++ b/app/weather/weather.go
@@ -1,0 +1,81 @@
+package weather
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const baseURL = "https://weather.tsukumijima.net/api/forecast/city/%s"
+
+// Forecast はtsukumijima天気APIのレスポンス構造体
+type Forecast struct {
+	Title     string        `json:"title"`
+	Forecasts []DayForecast `json:"forecasts"`
+}
+
+// DayForecast は1日分の天気予報
+type DayForecast struct {
+	DateLabel   string      `json:"dateLabel"`  // "今日", "明日", "明後日"
+	Telop       string      `json:"telop"`      // "晴れ" 等
+	Temperature Temperature `json:"temperature"`
+}
+
+// Temperature は最高・最低気温
+type Temperature struct {
+	Min *Celsius `json:"min"`
+	Max *Celsius `json:"max"`
+}
+
+// Celsius は摂氏気温
+type Celsius struct {
+	Celsius string `json:"celsius"`
+}
+
+// Fetch は指定したcityIDの天気予報を取得してテキストを返す
+func Fetch(ctx context.Context, cityID string) (string, error) {
+	url := fmt.Sprintf(baseURL, cityID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("リクエスト生成失敗: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("APIリクエスト失敗: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("APIエラー: ステータスコード %d", resp.StatusCode)
+	}
+
+	var forecast Forecast
+	if err := json.NewDecoder(resp.Body).Decode(&forecast); err != nil {
+		return "", fmt.Errorf("レスポンスのパース失敗: %w", err)
+	}
+
+	return formatForecast(&forecast), nil
+}
+
+// formatForecast は天気予報データをLINE送信用テキストに変換する
+func formatForecast(f *Forecast) string {
+	msg := fmt.Sprintf("【%s】\n", f.Title)
+	for _, d := range f.Forecasts {
+		if d.DateLabel != "今日" && d.DateLabel != "明日" {
+			continue
+		}
+		minTemp := "?"
+		maxTemp := "?"
+		if d.Temperature.Min != nil {
+			minTemp = d.Temperature.Min.Celsius
+		}
+		if d.Temperature.Max != nil {
+			maxTemp = d.Temperature.Max.Celsius
+		}
+		msg += fmt.Sprintf("%s: %s（最低%s℃ / 最高%s℃）\n", d.DateLabel, d.Telop, minTemp, maxTemp)
+	}
+	return msg
+}

--- a/app/weather_notify/weather_notify.go
+++ b/app/weather_notify/weather_notify.go
@@ -1,0 +1,48 @@
+package weather_notify
+
+import (
+	"context"
+	"log"
+
+	"github.com/commojun/nyanbot/app/weather"
+	"github.com/commojun/nyanbot/config"
+)
+
+type LineBot interface {
+	TextMessageWithRoomKey(ctx context.Context, msg string, roomKey string) error
+}
+
+// WeatherNotifier は朝の天気予報をプッシュ通知する
+type WeatherNotifier struct {
+	CityID  string
+	RoomKey string
+	Bot     LineBot
+}
+
+// New は WeatherNotifier を生成する
+func New(bot LineBot, cfg config.Config) *WeatherNotifier {
+	return &WeatherNotifier{
+		CityID:  cfg.WeatherCityID,
+		RoomKey: cfg.WeatherRoomKey,
+		Bot:     bot,
+	}
+}
+
+// Run は天気予報を取得してLINEに送信する
+func (wn *WeatherNotifier) Run(ctx context.Context) error {
+	if wn.CityID == "" {
+		log.Println("[weather_notify] NYAN_WEATHER_CITY_ID が未設定のためスキップ")
+		return nil
+	}
+	if wn.RoomKey == "" {
+		log.Println("[weather_notify] NYAN_WEATHER_ROOM_KEY が未設定のためスキップ")
+		return nil
+	}
+
+	msg, err := weather.Fetch(ctx, wn.CityID)
+	if err != nil {
+		return err
+	}
+
+	return wn.Bot.TextMessageWithRoomKey(ctx, msg, wn.RoomKey)
+}

--- a/cmd/nyan/nyan.go
+++ b/cmd/nyan/nyan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/commojun/nyanbot/app/hello"
 	"github.com/commojun/nyanbot/app/linebot"
 	"github.com/commojun/nyanbot/app/server"
+	"github.com/commojun/nyanbot/app/weather_notify"
 	"github.com/commojun/nyanbot/config"
 	"github.com/commojun/nyanbot/masterdata"
 )
@@ -25,6 +26,7 @@ type CLI struct {
 	Hello       HelloCmd       `cmd:"" help:"Send hello message"`
 	Alarm       AlarmCmd       `cmd:"" help:"Run alarm checker"`
 	Anniversary AnniversaryCmd `cmd:"" help:"Run anniversary checker"`
+	Weather     WeatherCmd     `cmd:"" help:"Send weather forecast"`
 }
 
 // ServerCmd: HTTP サーバーを起動
@@ -104,6 +106,26 @@ func (cmd *AnniversaryCmd) Run(cliCtx *CLI) error {
 
 	anniv := anniversary.New(bot)
 	return anniv.Run(ctx)
+}
+
+// WeatherCmd: 天気予報をLINEに送信する
+type WeatherCmd struct{}
+
+func (cmd *WeatherCmd) Run(cliCtx *CLI) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := masterdata.Initialize(ctx, cliCtx.Config); err != nil {
+		return err
+	}
+
+	bot, err := linebot.New(cliCtx.Config)
+	if err != nil {
+		return err
+	}
+
+	wn := weather_notify.New(bot, cliCtx.Config)
+	return wn.Run(ctx)
 }
 
 func main() {

--- a/config/config.go
+++ b/config/config.go
@@ -11,4 +11,6 @@ type Config struct {
 	GooglePrivateKeyID string `env:"NYAN_GOOGLE_PRIVATE_KEY_ID" help:"Google private key ID"`
 	GoogleTokenURL     string `env:"NYAN_GOOGLE_TOKEN_URL" help:"Google token URL"`
 	SheetID            string `required:"" env:"NYAN_SHEET_ID" help:"Google Sheet ID"`
+	WeatherCityID      string `env:"NYAN_WEATHER_CITY_ID" help:"天気予報の都市ID（例: 130010 = 東京）"`
+	WeatherRoomKey     string `env:"NYAN_WEATHER_ROOM_KEY" help:"天気予報の送信先ルームキー"`
 }

--- a/envfile.sample
+++ b/envfile.sample
@@ -12,3 +12,6 @@ NYAN_GOOGLE_PRIVATE_KEY_ID=private_key_id
 NYAN_GOOGLE_TOKEN_URL=https://oauth2.googleapis.com/token
 
 TUNNEL_TOKEN=hoge
+
+NYAN_WEATHER_CITY_ID=130010
+NYAN_WEATHER_ROOM_KEY=room_key

--- a/kube/weather.yml
+++ b/kube/weather.yml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: weather
+  namespace: nyan
+spec:
+  schedule: "0 22 * * *"  # JST 07:00 (UTC 22:00 前日)
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: weather
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: weather
+            image: commojun/nyanbot
+            command: ["nyan", "weather"]
+            envFrom:
+            - secretRef:
+                name: nyan-secret


### PR DESCRIPTION
関連Issue: https://github.com/commojun/nyanbot/issues/12

## 概要

livedoor天気API（廃止済み）の代替として [tsukumijima.net互換API](https://weather.tsukumijima.net/) を使い、天気予報通知機能を実装した。

- `天気` と送ると今日・明日の天気を返信（東京デフォルト）
- Kubernetes CronJob で毎朝7:00 JSTに自動通知（`nyan weather` サブコマンド）

## 変更点

- `app/weather/weather.go` 新規: tsukumijima API クライアント。`Fetch(ctx, cityID)` で天気テキストを返す
- `app/weather_notify/weather_notify.go` 新規: スケジュール通知ロジック。`NYAN_WEATHER_CITY_ID` / `NYAN_WEATHER_ROOM_KEY` 未設定時はスキップ
- `app/linebot/text_message_action/weather.go` 新規: `天気` プレフィックスに反応するインタラクティブアクション（東京固定）
- `app/linebot/text_message_action/text_message_action.go`: `actions()` に `getWeather` を追加
- `config/config.go`: `WeatherCityID`（`NYAN_WEATHER_CITY_ID`）・`WeatherRoomKey`（`NYAN_WEATHER_ROOM_KEY`）を追加
- `cmd/nyan/nyan.go`: `WeatherCmd` サブコマンドを追加
- `kube/weather.yml` 新規: `schedule: "0 22 * * *"`（JST 07:00）の CronJob
- `envfile.sample`: 上記2変数のサンプル値を追記